### PR TITLE
UX向上のためのボタン追加

### DIFF
--- a/src/app/api/races/[id]/navigation/route.ts
+++ b/src/app/api/races/[id]/navigation/route.ts
@@ -3,11 +3,14 @@ import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
-  const id = Number.parseInt(params.id)
+export async function GET(
+  request: Request, 
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
 
   const currentRace = await prisma.race.findUnique({
-    where: { id },
+    where: { id: Number(id) },
     select: { race_time: true },
   })
 

--- a/src/app/api/races/[id]/navigation/route.ts
+++ b/src/app/api/races/[id]/navigation/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server"
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const id = Number.parseInt(params.id)
+
+  const currentRace = await prisma.race.findUnique({
+    where: { id },
+    select: { race_time: true },
+  })
+
+  if (!currentRace || currentRace.race_time === null) {
+    return NextResponse.json({ error: "Race not found or race time is null" }, { status: 404 })
+  }
+
+  const prevRace = await prisma.race.findFirst({
+    where: {
+      race_time: {
+        lt: currentRace.race_time,
+      },
+    },
+    orderBy: {
+      race_time: "desc",
+    },
+    select: { id: true },
+  })
+
+  const nextRace = await prisma.race.findFirst({
+    where: {
+      race_time: {
+        gt: currentRace.race_time,
+      },
+    },
+    orderBy: {
+      race_time: "asc",
+    },
+    select: { id: true },
+  })
+
+  return NextResponse.json({ prevRaceId: prevRace?.id, nextRaceId: nextRace?.id })
+}
+

--- a/src/app/components/NavigationButtons.tsx
+++ b/src/app/components/NavigationButtons.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link"
+import { Button } from "@/app/components/ui/button"
+
+type Props = {
+  prevRaceId?: number
+  nextRaceId?: number
+}
+
+export function NavigationButtons({ prevRaceId, nextRaceId }: Props) {
+  return (
+    <div className="flex justify-between items-center my-4">
+      <Button variant="outline" disabled={!prevRaceId} asChild className="bg-gray-200 hover:bg-gray-300 text-gray-800">
+        <Link href={prevRaceId ? `/races/${prevRaceId}` : "#"}>前のレース</Link>
+      </Button>
+      <Button variant="outline" asChild className="bg-black hover:bg-gray-800 text-white">
+        <Link href="/">一覧に戻る</Link>
+      </Button>
+      <Button variant="outline" disabled={!nextRaceId} asChild className="bg-gray-200 hover:bg-gray-300 text-gray-800">
+        <Link href={nextRaceId ? `/races/${nextRaceId}` : "#"}>次のレース</Link>
+      </Button>
+    </div>
+  )
+}
+

--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card"
 import { EntryTable } from "@/app/components/EntryTable"
 import { Race, Entry, Predict } from "@prisma/client"
+import { NavigationButtons } from "@/app/components/NavigationButtons"
 
 type EntryWithMasters = Entry & {
   HorseMaster: { name: string }
@@ -20,9 +21,17 @@ async function getRaceWithEntries(id: number): Promise<RaceWithEntriesAndPredict
   return res.json();
 }
 
+async function getNavigation(id: number): Promise<{ prevRaceId?: number; nextRaceId?: number }> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/races/${id}/navigation`, { cache: "no-store" })
+  if (!res.ok) {
+    throw new Error("Failed to fetch navigation")
+  }
+  return res.json()
+}
+
 export default async function RacePage({ params }: { params: Promise<{ id: number }> }) {
   const { id } = await params;
-  const race = await getRaceWithEntries(id)
+  const [race, navigation] = await Promise.all([getRaceWithEntries(id), getNavigation(id)])
 
   if (!race) {
     return <div>レースが見つかりません</div>
@@ -46,6 +55,7 @@ export default async function RacePage({ params }: { params: Promise<{ id: numbe
         </CardContent>
       </Card>
       <EntryTable entries={race.entries} predicts={race.predicts} />
+      <NavigationButtons prevRaceId={navigation.prevRaceId} nextRaceId={navigation.nextRaceId} />
     </main>
   )
 }


### PR DESCRIPTION
レース一覧ボタン・他のレースに移るボタンを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - レースのナビゲーション情報の取得が可能になりました。ユーザーは、現在のレースに基づき前後のレース情報に簡単にアクセスできるようになりました。
  - 新たなナビゲーションボタンが追加され、レースページ上で「前のレース」、「ホーム」、および「次のレース」へスムーズに移動できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->