### PR TITLE
推奨馬券テーブルを追加し、Raceモデルに関連付けを設定

### DIFF
--- a/prisma/migrations/20250504071106_add_recommended_bets_table/migration.sql
+++ b/prisma/migrations/20250504071106_add_recommended_bets_table/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "RecommendedBet" (
+    "id" SERIAL NOT NULL,
+    "race_id" INTEGER NOT NULL,
+    "bet_type" TEXT NOT NULL,
+    "numbers" TEXT NOT NULL,
+    "payout" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "RecommendedBet_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "RecommendedBet" ADD CONSTRAINT "RecommendedBet_race_id_fkey" FOREIGN KEY ("race_id") REFERENCES "Race"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ model Race {
   predicts         Predict[]
   results          Result[]
   payouts          Payout[]
+  recommended_bets RecommendedBet[]
 }
 
 model Result {
@@ -101,4 +102,16 @@ model Payout {
   created_at  DateTime @default(now()) @db.Timestamptz(6)
   updated_at  DateTime @default(now()) @db.Timestamptz(6)
   Race        Race @relation(fields: [race_id], references: [id])
+}
+
+model RecommendedBet {
+  id            Int      @id @default(autoincrement())
+  race_id       Int
+  bet_type      String  // 馬券の種類
+  numbers       String  // 組み合わせ (例: "1-2", "3")
+  payout        Int     @default(0) // 的中時の配当
+  created_at    DateTime @default(now()) @db.Timestamptz(6)
+  updated_at    DateTime @updatedAt @db.Timestamptz(6)
+
+  Race          Race     @relation(fields: [race_id], references: [id])
 }


### PR DESCRIPTION
Prtismaのマイグレーションファイルに推奨馬券テーブルを作成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 推奨ベット情報を管理する新しい機能が追加されました。レースごとにベットタイプや番号、払戻金額などの情報を記録できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->