### PR TITLE
Display nearest race date on home page

### DIFF
--- a/src/app/api/races/route.ts
+++ b/src/app/api/races/route.ts
@@ -7,9 +7,51 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const dateParam = searchParams.get('date');
   
-  // デフォルトは今日の日付
-  const today = new Date();
-  const targetDate = dateParam ? new Date(dateParam) : today;
+  // 日付指定がない場合は、直近で開催されるレースの日付を取得する
+  let targetDate: Date
+
+  if (dateParam) {
+    targetDate = new Date(dateParam)
+  } else {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    // まず今日以降で最も近いレース日を探す
+    const nextRace = await prisma.race.findFirst({
+      where: {
+        race_time: {
+          gte: today,
+        },
+      },
+      orderBy: {
+        race_time: 'asc',
+      },
+      select: {
+        race_time: true,
+      },
+    })
+
+    if (nextRace?.race_time) {
+      targetDate = nextRace.race_time
+    } else {
+      // 今後のレースがなければ直近の過去のレース日を取得
+      const prevRace = await prisma.race.findFirst({
+        where: {
+          race_time: {
+            lt: today,
+          },
+        },
+        orderBy: {
+          race_time: 'desc',
+        },
+        select: {
+          race_time: true,
+        },
+      })
+
+      targetDate = prevRace?.race_time ?? today
+    }
+  }
   
   // 指定された日付の00:00:00から23:59:59までのレースを取得
   const startOfDay = new Date(targetDate);

--- a/src/app/components/DateSelector.tsx
+++ b/src/app/components/DateSelector.tsx
@@ -34,13 +34,15 @@ export function DateSelector({ selectedDate, onDateChange }: DateSelectorProps) 
   }, [])
 
   const formatDateLabel = (dateStr: string) => {
+    if (!dateStr) return ''
     const date = new Date(dateStr)
+    if (isNaN(date.getTime())) return ''
     const today = new Date()
     const isToday = format(today, 'yyyy-MM-dd') === dateStr
-    
+
     let label = format(date, 'M月d日')
     if (isToday) label += ' (今日)'
-    
+
     return label
   }
 
@@ -104,7 +106,7 @@ export function DateSelector({ selectedDate, onDateChange }: DateSelectorProps) 
         >
           <span>日付選択</span>
           <div className="flex items-center gap-2">
-            <span className="text-sm">{formatDateLabel(selectedDate)}</span>
+            <span className="text-sm">{selectedDate ? formatDateLabel(selectedDate) : ''}</span>
             <svg
               className={`w-4 h-4 transform transition-transform ${isOpen ? 'rotate-180' : ''}`}
               fill="none"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,8 +11,38 @@ import { format } from "date-fns"
 
 export default function Home() {
   const [races, setRaces] = useState<Race[]>([])
-  const [selectedDate, setSelectedDate] = useState(() => format(new Date(), 'yyyy-MM-dd'))
+  const [selectedDate, setSelectedDate] = useState<string>("")
   const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const res = await fetch('/api/races/dates')
+        if (res.ok) {
+          const dates: string[] = await res.json()
+          if (dates.length > 0) {
+            const today = new Date()
+            let closest = dates[0]
+            let minDiff = Math.abs(new Date(dates[0]).getTime() - today.getTime())
+            for (const dateStr of dates) {
+              const diff = Math.abs(new Date(dateStr).getTime() - today.getTime())
+              if (diff < minDiff) {
+                minDiff = diff
+                closest = dateStr
+              }
+            }
+            setSelectedDate(closest)
+          } else {
+            setSelectedDate(format(new Date(), 'yyyy-MM-dd'))
+          }
+        }
+      } catch (error) {
+        console.error('Error initializing date:', error)
+        setSelectedDate(format(new Date(), 'yyyy-MM-dd'))
+      }
+    }
+    init()
+  }, [])
 
   const fetchRaces = async (date: string) => {
     setLoading(true)
@@ -32,7 +62,9 @@ export default function Home() {
   }
 
   useEffect(() => {
-    fetchRaces(selectedDate)
+    if (selectedDate) {
+      fetchRaces(selectedDate)
+    }
   }, [selectedDate])
 
   const backgroundImages = [


### PR DESCRIPTION
## Summary
- select the nearest race date when none is specified in the API
- initialize the home page with that nearest available date

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406d7752b0832a9928cbff2b4f4986

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - レース日付の自動選択ロジックを改善し、最も近い開催予定日または直近の過去日を自動で選択するようになりました。

- **バグ修正**
  - 日付選択時、無効または空の日付が指定された場合に正しく処理されるようになりました。
  - レースデータの取得が、日付が適切に初期化された後のみ実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->