### PR TITLE
レース開始時刻表示修正

### DIFF
--- a/src/app/components/RaceCard.tsx
+++ b/src/app/components/RaceCard.tsx
@@ -2,6 +2,7 @@ import { Card } from "@/app/components/ui/card"
 import { Race } from "@prisma/client"
 import Link from "next/link"
 import { Badge } from "@/app/components/ui/badge"
+import { formatInTimeZone } from "date-fns-tz"
 
 function getGradientClass(courseType: string): string {
   switch (courseType) {
@@ -18,7 +19,9 @@ function getGradientClass(courseType: string): string {
 
 export function RaceCard({ race }: { race: Race }) {
   const raceTime = race.race_time ? new Date(race.race_time) : null
-  const formattedTime = raceTime ? raceTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }) : "N/A"
+  const formattedTime = raceTime
+    ? formatInTimeZone(raceTime, 'UTC', 'HH:mm')
+    : "N/A"
 
   return (
     <Link href={`/races/${race.id}`} className="block mb-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { Race } from "@prisma/client"
 import Image from "next/image"
 import { useState, useEffect } from "react"
 import { format } from "date-fns"
+import { formatInTimeZone } from "date-fns-tz"
 
 export default function Home() {
   const [races, setRaces] = useState<Race[]>([])
@@ -78,8 +79,10 @@ export default function Home() {
   }
 
   const groupedRaces = groupBy(races, (race) => {
-    const date = race.race_time ? new Date(race.race_time) : new Date()
-    return date.toISOString().split('T')[0]
+    if (race.race_time) {
+      return formatInTimeZone(new Date(race.race_time), 'UTC', 'yyyy-MM-dd')
+    }
+    return formatInTimeZone(new Date(), 'UTC', 'yyyy-MM-dd')
   })
 
   return (

--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -5,6 +5,7 @@ import { PayoutTable } from "@/app/components/PayoutTable"
 import { Race, Entry, Predict, Result, Payout } from "@prisma/client"
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
+import { formatInTimeZone } from "date-fns-tz"
 
 type EntryWithMasters = Entry & {
   HorseMaster: { name: string }
@@ -56,8 +57,12 @@ export default async function RacePage({ params }: { params: Promise<{ id: numbe
     return <div>レースが見つかりません</div>
   }
   const raceTime = race.race_time ? new Date(race.race_time) : null
-  const formattedDate = raceTime ? raceTime.toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' }) : "N/A"
-  const formattedTime = raceTime ? raceTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }) : "N/A"
+  const formattedDate = raceTime
+    ? formatInTimeZone(raceTime, 'UTC', 'yyyy年M月d日')
+    : "N/A"
+  const formattedTime = raceTime
+    ? formatInTimeZone(raceTime, 'UTC', 'HH:mm')
+    : "N/A"
   // const now = new Date()
   // const raceHasFinished = new Date(race.race_time) < now
 


### PR DESCRIPTION
## Summary
- display race time without timezone shift
- group races by date using UTC formatting

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fe44ea88832a8ffa54dc423234ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - レースの日付と時刻の表示形式が、すべてUTCタイムゾーン基準に統一されました。これにより、表示されるレース情報の日時が一貫したフォーマット（例: "HH:mm" や "yyyy年M月d日"）で確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->