### PR TITLE
Supabaseを参照

### DIFF
--- a/src/app/api/races/[id]/route.ts
+++ b/src/app/api/races/[id]/route.ts
@@ -21,6 +21,7 @@ export async function GET(
       predicts: true,
       results: true,
       payouts: true,
+      recommended_bets: true,
     },
   });
 

--- a/src/app/components/RecommendedBets.tsx
+++ b/src/app/components/RecommendedBets.tsx
@@ -101,8 +101,8 @@ export function RecommendedBets({ bets }: Props) {
             <h3 className="text-lg font-semibold mb-3 text-center">的中結果</h3>
             <div className="space-y-4">
               <ul className="space-y-2">
-                {hitDetails.map((hit, index) => (
-                  <li key={index} className="flex justify-between items-center pb-1">
+                {hitDetails.map((hit) => (
+                  <li key={`${hit.type}-${hit.numbers}`} className="flex justify-between items-center pb-1">
                     <span>
                       {hit.type} {hit.numbers}
                     </span>

--- a/src/app/components/RecommendedBets.tsx
+++ b/src/app/components/RecommendedBets.tsx
@@ -57,6 +57,10 @@ export function RecommendedBets({ bets }: Props) {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {Object.entries(grouped).map(([betType, betGroup]) => {
             const total = betGroup.reduce((sum, b) => sum + b.bet, 0)
+            const sorted =
+              betType === "複勝"
+                ? [...betGroup].sort((a, b) => b.bet - a.bet)
+                : betGroup
             if (betType === "ワイド" || betType === "三連複" || betType === "3連複") {
               const nums = uniqueNumbers(betGroup)
               return (
@@ -74,7 +78,7 @@ export function RecommendedBets({ bets }: Props) {
               <div key={betType} className="bg-gray-50 p-4 rounded-lg">
                 <h3 className="text-lg font-semibold mb-3 text-center">{betType}</h3>
                 <ul className="space-y-2">
-                  {betGroup.map((bet) => (
+                  {sorted.map((bet) => (
                     <li key={bet.id} className="pb-1 last:border-b-0">
                       {bet.numbers} - {bet.bet}円
                     </li>

--- a/src/app/components/RecommendedBets.tsx
+++ b/src/app/components/RecommendedBets.tsx
@@ -2,6 +2,21 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/ca
 import type { RecommendedBet } from "@prisma/client"
 import { groupBy } from "lodash"
 
+function uniqueNumbers(bets: RecommendedBet[]): string {
+  const nums = new Set<number>()
+  bets.forEach((b) => {
+    b.numbers
+      .split(/[-,]/)
+      .map((n) => parseInt(n, 10))
+      .forEach((n) => {
+        if (!isNaN(n)) nums.add(n)
+      })
+  })
+  return Array.from(nums)
+    .sort((a, b) => a - b)
+    .join(',')
+}
+
 interface Props {
   bets: RecommendedBet[]
 }
@@ -40,21 +55,37 @@ export function RecommendedBets({ bets }: Props) {
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {Object.entries(grouped).map(([betType, betGroup]) => (
-            <div key={betType} className="bg-gray-50 p-4 rounded-lg">
-              <h3 className="text-lg font-semibold mb-3 text-center">{betType}</h3>
-              <ul className="space-y-2">
-                {betGroup.map((bet) => (
-                  <li key={bet.id} className="pb-1 last:border-b-0">
-                    {bet.numbers} - {bet.bet}円
-                  </li>
-                ))}
-              </ul>
-              <p className="mt-2 text-sm text-gray-600 font-semibold text-right">
-                合計: {betGroup.reduce((sum, b) => sum + b.bet, 0)}円
-              </p>
-            </div>
-          ))}
+          {Object.entries(grouped).map(([betType, betGroup]) => {
+            const total = betGroup.reduce((sum, b) => sum + b.bet, 0)
+            if (betType === "ワイド" || betType === "三連複" || betType === "3連複") {
+              const nums = uniqueNumbers(betGroup)
+              return (
+                <div key={betType} className="bg-gray-50 p-4 rounded-lg">
+                  <h3 className="text-lg font-semibold mb-3 text-center">{betType}</h3>
+                  <div className="flex flex-col items-center justify-center h-full">
+                    <p className="text-center mb-3">ボックス: {nums}</p>
+                    <p className="text-sm text-gray-600">各{betGroup[0].bet}円 × {betGroup.length}通り</p>
+                    <p className="mt-2 text-sm text-gray-600 font-semibold">合計: {total}円</p>
+                  </div>
+                </div>
+              )
+            }
+            return (
+              <div key={betType} className="bg-gray-50 p-4 rounded-lg">
+                <h3 className="text-lg font-semibold mb-3 text-center">{betType}</h3>
+                <ul className="space-y-2">
+                  {betGroup.map((bet) => (
+                    <li key={bet.id} className="pb-1 last:border-b-0">
+                      {bet.numbers} - {bet.bet}円
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-2 text-sm text-gray-600 font-semibold text-right">
+                  合計: {total}円
+                </p>
+              </div>
+            )
+          })}
         </div>
 
         <div className="mt-6 pt-4 border-t text-center">

--- a/src/app/components/RecommendedBets.tsx
+++ b/src/app/components/RecommendedBets.tsx
@@ -1,125 +1,30 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card"
-import type { Entry, Predict, Payout } from "@prisma/client"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/app/components/ui/table"
+import type { RecommendedBet } from "@prisma/client"
+import { groupBy } from "lodash"
 
-type EntryWithMasters = Entry & {
-  HorseMaster: { name: string }
-  JockeyMaster: { name: string }
-  result?: {
-    order: number
-    popularity: number
-    odds: number
-  }
+interface Props {
+  bets: RecommendedBet[]
 }
 
-type Props = {
-  entries: EntryWithMasters[]
-  predicts: Predict[]
-  payouts?: Payout[]
-}
-
-export function RecommendedBets({ entries, predicts, payouts = [] }: Props) {
-  // スコアの高い順に上位4頭を選出
-  const topHorses = [...predicts]
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 4)
-    .map((predict) => {
-      const entry = entries.find((e) => e.horse_number === predict.horse_number)
-      return {
-        horse_number: predict.horse_number,
-        horse_name: entry?.HorseMaster?.name || "不明",
-        score: predict.score,
-      }
-    })
-
-  // 複勝の金額
-  const tanaBets = [
-    { horse: topHorses[0], amount: 400 },
-    { horse: topHorses[1], amount: 300 },
-    { horse: topHorses[2], amount: 200 },
-    { horse: topHorses[3], amount: 100 },
-  ].filter((bet) => bet.horse) // undefined のホースを除外
-
-  // ワイドの組み合わせ数
-  const wideCount = (topHorses.length * (topHorses.length - 1)) / 2
-
-  // 三連複の組み合わせ数
-  const sanrenpukuCount = (topHorses.length * (topHorses.length - 1) * (topHorses.length - 2)) / 6
-
-  // 合計金額を計算
-  const totalAmount = tanaBets.reduce((sum, bet) => sum + bet.amount, 0) + wideCount * 100 + sanrenpukuCount * 100
-
-  // 馬番のリスト（ソート済み）
-  const horseNumbers = topHorses.map((horse) => horse.horse_number).sort((a, b) => a - b)
-  const horseNumbersStr = horseNumbers.join(",")
-
-  // 的中判定と配当計算
-  let hitAmount = 0
-  const hitDetails = []
-
-  if (payouts.length > 0) {
-    // 複勝の的中判定
-    const fukushoPayouts = payouts.filter((p) => p.bet_type === "複勝")
-    const hitFukusho = tanaBets.filter((bet) =>
-      fukushoPayouts.some((p) => p.numbers === String(bet.horse.horse_number)),
+export function RecommendedBets({ bets }: Props) {
+  if (bets.length === 0) {
+    return (
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle>レコメンド馬券</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-center text-gray-600">レコメンド馬券はまだ登録されていません</p>
+        </CardContent>
+      </Card>
     )
-
-    hitFukusho.forEach((bet) => {
-      const payout = fukushoPayouts.find((p) => p.numbers === String(bet.horse.horse_number))
-      if (payout) {
-        const fukusyoHitAmount = Math.floor((bet.amount / 100) * payout.payout)
-        hitDetails.push({
-          type: "複勝",
-          numbers: bet.horse.horse_number,
-          investment: bet.amount,
-          return: fukusyoHitAmount,
-        })
-        hitAmount += fukusyoHitAmount
-      }
-    })
-
-    // ワイドの的中判定
-    const widePayouts = payouts.filter((p) => p.bet_type === "ワイド")
-    for (let i = 0; i < horseNumbers.length; i++) {
-      for (let j = i + 1; j < horseNumbers.length; j++) {
-        const combo = [horseNumbers[i], horseNumbers[j]].sort((a, b) => a - b).join("-")
-        const payout = widePayouts.find((p) => p.numbers === combo)
-        if (payout) {
-          const wideHitAmount = payout.payout
-          hitDetails.push({
-            type: "ワイド",
-            numbers: combo,
-            investment: 100,
-            return: wideHitAmount,
-          })
-          hitAmount += wideHitAmount
-        }
-      }
-    }
-
-    // 三連複の的中判定
-    const sanrenpukuPayouts = payouts.filter((p) => p.bet_type === "3連複")
-    for (let i = 0; i < horseNumbers.length; i++) {
-      for (let j = i + 1; j < horseNumbers.length; j++) {
-        for (let k = j + 1; k < horseNumbers.length; k++) {
-          const combo = [horseNumbers[i], horseNumbers[j], horseNumbers[k]].sort((a, b) => a - b).join("-")
-          const payout = sanrenpukuPayouts.find((p) => p.numbers === combo)
-          if (payout) {
-            const sanrenpukuHitAmount = payout.payout
-            hitDetails.push({
-              type: "三連複",
-              numbers: combo,
-              investment: 100,
-              return: sanrenpukuHitAmount,
-            })
-            hitAmount += sanrenpukuHitAmount
-          }
-        }
-      }
-    }
   }
 
-  // 収支計算
-  const balance = hitAmount - totalAmount
+  const grouped = groupBy(bets, "bet_type")
+  const totalBet = bets.reduce((sum, b) => sum + b.bet, 0)
+  const totalReturn = bets.reduce((sum, b) => sum + b.payout, 0)
+  const balance = totalReturn - totalBet
 
   return (
     <Card className="mt-8">
@@ -127,86 +32,56 @@ export function RecommendedBets({ entries, predicts, payouts = [] }: Props) {
         <CardTitle>レコメンド馬券</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-gray-50 p-4 rounded-lg">
-            <h3 className="text-lg font-semibold mb-3 text-center">複勝</h3>
-            <ul className="space-y-2">
-              {tanaBets.map((bet, index) => (
-                <li key={index} className="pb-1 last:border-b-0">
-                  {bet.horse.horse_number}番 {bet.horse.horse_name} - {bet.amount}円
-                </li>
-              ))}
-            </ul>
-            <p className="mt-2 text-sm text-gray-600 font-semibold text-right">
-              合計: {tanaBets.reduce((sum, bet) => sum + bet.amount, 0)}円
-            </p>
-          </div>
-
-          <div className="bg-gray-50 p-4 rounded-lg">
-            <h3 className="text-lg font-semibold mb-3 text-center">ワイド</h3>
-            <div className="flex flex-col items-center justify-center h-full">
-              <p className="text-center mb-3">ボックス: {horseNumbersStr}</p>
-              <p className="text-sm text-gray-600">各100円 × {wideCount}通り</p>
-              <p className="mt-2 text-sm text-gray-600 font-semibold">合計: {wideCount * 100}円</p>
-            </div>
-          </div>
-
-          <div className="bg-gray-50 p-4 rounded-lg">
-            <h3 className="text-lg font-semibold mb-3 text-center">三連複</h3>
-            <div className="flex flex-col items-center justify-center h-full">
-              <p className="text-center mb-3">ボックス: {horseNumbersStr}</p>
-              <p className="text-sm text-gray-600">各100円 × {sanrenpukuCount}通り</p>
-              <p className="mt-2 text-sm text-gray-600 font-semibold">合計: {sanrenpukuCount * 100}円</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-6 pt-4 border-t text-center">
-          <p className="font-bold text-lg">合計金額: {totalAmount}円</p>
-        </div>
-
-        {payouts.length > 0 && (
-          <div className="mt-6 pt-4 border-t">
-            <h3 className="text-lg font-semibold mb-3 text-center">的中結果</h3>
-            {hitDetails.length > 0 ? (
-              <div className="space-y-4">
-                <ul className="space-y-2">
-                  {hitDetails.map((hit, index) => (
-                    <li key={index} className="flex justify-between items-center pb-1">
-                      <span>
-                        {hit.type} {hit.numbers}
-                      </span>
-                      <span className="font-semibold text-green-600">+{hit.return.toLocaleString()}円</span>
-                    </li>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>式別</TableHead>
+              <TableHead>馬番</TableHead>
+              <TableHead>購入金額</TableHead>
+              <TableHead>払戻</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {Object.entries(grouped).map(([betType, betGroup]) => (
+              <TableRow key={betType}>
+                <TableCell>{betType}</TableCell>
+                <TableCell>
+                  {betGroup.map((b) => (
+                    <div key={b.id}>{b.numbers}</div>
                   ))}
-                </ul>
-                <div className="flex justify-between items-center pt-2">
-                  <span className="font-bold">投資金額</span>
-                  <span>{totalAmount.toLocaleString()}円</span>
-                </div>
-                <div className="flex justify-between items-center pt-2">
-                  <span className="font-bold">回収金額</span>
-                  <span>{hitAmount.toLocaleString()}円</span>
-                </div>
-                <div className="flex justify-between items-center pt-2 border-t">
-                  <span className="font-bold">収支</span>
-                  <span className={balance >= 0 ? "text-green-600 font-bold" : "text-red-600 font-bold"}>
-                    {balance >= 0 ? "+" : ""}
-                    {balance.toLocaleString()}円
-                  </span>
-                </div>
-                <div className="flex justify-between items-center pt-2">
-                  <span className="font-bold">回収率</span>
-                  <span className={balance >= 0 ? "text-green-600 font-bold" : "text-red-600 font-bold"}>
-                    {totalAmount > 0 ? Math.round((hitAmount / totalAmount) * 100) : 0}%
-                  </span>
-                </div>
-              </div>
-            ) : (
-              <p className="text-center text-gray-600">的中馬券はありませんでした</p>
-            )}
-          </div>
-        )}
+                </TableCell>
+                <TableCell>
+                  {betGroup.map((b) => (
+                    <div key={b.id}>{b.bet.toLocaleString()}円</div>
+                  ))}
+                </TableCell>
+                <TableCell>
+                  {betGroup.map((b) => (
+                    <div key={b.id}>{b.payout.toLocaleString()}円</div>
+                  ))}
+                </TableCell>
+              </TableRow>
+            ))}
+            <TableRow>
+              <TableCell colSpan={2} className="font-bold text-right">
+                合計
+              </TableCell>
+              <TableCell className="font-bold">
+                {totalBet.toLocaleString()}円
+              </TableCell>
+              <TableCell className="font-bold">
+                {totalReturn.toLocaleString()}円
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+        <div className="mt-4 text-center font-bold">
+          収支:{" "}
+          <span className={balance >= 0 ? "text-green-600" : "text-red-600"}>
+            {balance >= 0 ? "+" : ""}
+            {balance.toLocaleString()}円
+          </span>
+        </div>
       </CardContent>
     </Card>
   )

--- a/src/app/components/RecommendedBets.tsx
+++ b/src/app/components/RecommendedBets.tsx
@@ -1,5 +1,4 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/app/components/ui/table"
 import type { RecommendedBet } from "@prisma/client"
 import { groupBy } from "lodash"
 
@@ -22,9 +21,17 @@ export function RecommendedBets({ bets }: Props) {
   }
 
   const grouped = groupBy(bets, "bet_type")
-  const totalBet = bets.reduce((sum, b) => sum + b.bet, 0)
-  const totalReturn = bets.reduce((sum, b) => sum + b.payout, 0)
-  const balance = totalReturn - totalBet
+  const totalAmount = bets.reduce((sum, b) => sum + b.bet, 0)
+  const hitDetails = bets
+    .filter((b) => b.payout > 0)
+    .map((b) => ({
+      type: b.bet_type,
+      numbers: b.numbers,
+      investment: b.bet,
+      return: b.payout,
+    }))
+  const hitAmount = hitDetails.reduce((sum, h) => sum + h.return, 0)
+  const balance = hitAmount - totalAmount
 
   return (
     <Card className="mt-8">
@@ -32,56 +39,66 @@ export function RecommendedBets({ bets }: Props) {
         <CardTitle>レコメンド馬券</CardTitle>
       </CardHeader>
       <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>式別</TableHead>
-              <TableHead>馬番</TableHead>
-              <TableHead>購入金額</TableHead>
-              <TableHead>払戻</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {Object.entries(grouped).map(([betType, betGroup]) => (
-              <TableRow key={betType}>
-                <TableCell>{betType}</TableCell>
-                <TableCell>
-                  {betGroup.map((b) => (
-                    <div key={b.id}>{b.numbers}</div>
-                  ))}
-                </TableCell>
-                <TableCell>
-                  {betGroup.map((b) => (
-                    <div key={b.id}>{b.bet.toLocaleString()}円</div>
-                  ))}
-                </TableCell>
-                <TableCell>
-                  {betGroup.map((b) => (
-                    <div key={b.id}>{b.payout.toLocaleString()}円</div>
-                  ))}
-                </TableCell>
-              </TableRow>
-            ))}
-            <TableRow>
-              <TableCell colSpan={2} className="font-bold text-right">
-                合計
-              </TableCell>
-              <TableCell className="font-bold">
-                {totalBet.toLocaleString()}円
-              </TableCell>
-              <TableCell className="font-bold">
-                {totalReturn.toLocaleString()}円
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-        <div className="mt-4 text-center font-bold">
-          収支:{" "}
-          <span className={balance >= 0 ? "text-green-600" : "text-red-600"}>
-            {balance >= 0 ? "+" : ""}
-            {balance.toLocaleString()}円
-          </span>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {Object.entries(grouped).map(([betType, betGroup]) => (
+            <div key={betType} className="bg-gray-50 p-4 rounded-lg">
+              <h3 className="text-lg font-semibold mb-3 text-center">{betType}</h3>
+              <ul className="space-y-2">
+                {betGroup.map((bet) => (
+                  <li key={bet.id} className="pb-1 last:border-b-0">
+                    {bet.numbers} - {bet.bet}円
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-2 text-sm text-gray-600 font-semibold text-right">
+                合計: {betGroup.reduce((sum, b) => sum + b.bet, 0)}円
+              </p>
+            </div>
+          ))}
         </div>
+
+        <div className="mt-6 pt-4 border-t text-center">
+          <p className="font-bold text-lg">合計金額: {totalAmount}円</p>
+        </div>
+
+        {hitDetails.length > 0 && (
+          <div className="mt-6 pt-4 border-t">
+            <h3 className="text-lg font-semibold mb-3 text-center">的中結果</h3>
+            <div className="space-y-4">
+              <ul className="space-y-2">
+                {hitDetails.map((hit, index) => (
+                  <li key={index} className="flex justify-between items-center pb-1">
+                    <span>
+                      {hit.type} {hit.numbers}
+                    </span>
+                    <span className="font-semibold text-green-600">+{hit.return.toLocaleString()}円</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="flex justify-between items-center pt-2">
+                <span className="font-bold">投資金額</span>
+                <span>{totalAmount.toLocaleString()}円</span>
+              </div>
+              <div className="flex justify-between items-center pt-2">
+                <span className="font-bold">回収金額</span>
+                <span>{hitAmount.toLocaleString()}円</span>
+              </div>
+              <div className="flex justify-between items-center pt-2 border-t">
+                <span className="font-bold">収支</span>
+                <span className={balance >= 0 ? "text-green-600 font-bold" : "text-red-600 font-bold"}>
+                  {balance >= 0 ? "+" : ""}
+                  {balance.toLocaleString()}円
+                </span>
+              </div>
+              <div className="flex justify-between items-center pt-2">
+                <span className="font-bold">回収率</span>
+                <span className={balance >= 0 ? "text-green-600 font-bold" : "text-red-600 font-bold"}>
+                  {totalAmount > 0 ? Math.round((hitAmount / totalAmount) * 100) : 0}%
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent } from "@/app/components/ui/card"
 import { EntryTable } from "@/app/components/EntryTable"
 import { RaceResultTable } from "@/app/components/RaceResultTable"
 import { PayoutTable } from "@/app/components/PayoutTable"
-import { Race, Entry, Predict, Result, Payout } from "@prisma/client"
+import { Race, Entry, Predict, Result, Payout, RecommendedBet } from "@prisma/client"
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
 import { formatInTimeZone } from "date-fns-tz"
@@ -17,6 +17,7 @@ type RaceWithEntriesAndPredicts = Race & {
   predicts: Predict[]
   results: Result[]
   payouts: Payout[]
+  recommended_bets: RecommendedBet[]
 }
 
 function getGradientClass(courseType: string): string {
@@ -79,7 +80,7 @@ export default async function RacePage({ params }: { params: Promise<{ id: numbe
         </CardContent>
       </Card>
       <EntryTable entries={race.entries} predicts={race.predicts} />
-      <RecommendedBets entries={race.entries} predicts={race.predicts}  payouts={race.payouts} />
+      <RecommendedBets bets={race.recommended_bets} />
       <div className="mt-6 flex gap-6">
         {race.results && race.results.length > 0 && (
           <div className="flex-1">


### PR DESCRIPTION
## Summary
- expose recommended_bets via race API
- render recommended bets from DB

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685674cfedc8832a83375160ed8e9523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - レース詳細ページで「おすすめ馬券」情報が表示されるようになりました。

- **リファクタリング**
  - 「おすすめ馬券」表示コンポーネントのUIと計算ロジックがシンプルなテーブル形式に整理され、見やすくなりました。  
  - 複雑な手計算や詳細な的中内訳表示が削除され、合計金額や収支が分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->