### PR TITLE
Fix hide races older than one month from the top page

### DIFF
--- a/src/app/api/races/dates/route.ts
+++ b/src/app/api/races/dates/route.ts
@@ -5,11 +5,14 @@ const prisma = new PrismaClient();
 
 export async function GET() {
   try {
+    const oldestVisibleRaceTime = new Date();
+    oldestVisibleRaceTime.setMonth(oldestVisibleRaceTime.getMonth() - 1);
+
     // レースが存在する日付の一覧を取得（重複なし、降順）
     const raceDates = await prisma.race.findMany({
       where: {
         race_time: {
-          not: null,
+          gte: oldestVisibleRaceTime,
         },
       },
       select: {

--- a/src/app/api/races/route.ts
+++ b/src/app/api/races/route.ts
@@ -6,6 +6,8 @@ const prisma = new PrismaClient();
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const dateParam = searchParams.get('date');
+  const oldestVisibleRaceTime = new Date();
+  oldestVisibleRaceTime.setMonth(oldestVisibleRaceTime.getMonth() - 1);
   
   // 日付指定がない場合は、直近で開催されるレースの日付を取得する
   let targetDate: Date
@@ -38,6 +40,7 @@ export async function GET(request: Request) {
       const prevRace = await prisma.race.findFirst({
         where: {
           race_time: {
+            gte: oldestVisibleRaceTime,
             lt: today,
           },
         },
@@ -56,6 +59,7 @@ export async function GET(request: Request) {
   // 指定された日付の00:00:00から23:59:59までのレースを取得
   const startOfDay = new Date(targetDate);
   startOfDay.setHours(0, 0, 0, 0);
+  const visibleStartTime = startOfDay > oldestVisibleRaceTime ? startOfDay : oldestVisibleRaceTime;
   
   const endOfDay = new Date(targetDate);
   endOfDay.setHours(23, 59, 59, 999);
@@ -63,7 +67,7 @@ export async function GET(request: Request) {
   const races = await prisma.race.findMany({
     where: {
       race_time: {
-        gte: startOfDay,
+        gte: visibleStartTime,
         lte: endOfDay,
       },
     },


### PR DESCRIPTION
## Summary
- Restrict top-page race fetching to races within the last month
- Apply the same cutoff to available date lists so outdated dates no longer appear in the selector
- Keep the default top-page behavior aligned with the visible date window

## Testing
- Local lint validation passed with the project Node 22 environment
- Verified the updated API logic by reviewing the filtered race/date responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * レース検索機能を改善し、フィルタリング処理を更新しました。今後、過去1ヶ月以内の開催予定レースと今後のレースのみを検索結果に表示します。この変更はレース日付の選択時とレース一覧の取得時の両方に適用されます。従来より古い記録は表示されません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->