### PR TITLE
feat: メンテナンスモードを追加

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function isMaintenanceModeEnabled(): boolean {
+  return process.env.MAINTENANCE_MODE === "true";
+}
+
+function createMaintenanceResponse(): NextResponse {
+  return new NextResponse(
+    `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>メンテナンス中 | Horecast</title>
+  </head>
+  <body style="margin:0;display:grid;min-height:100vh;place-items:center;background:#f8fafc;color:#0f172a;font-family:system-ui,sans-serif">
+    <main style="max-width:32rem;padding:2rem;text-align:center">
+      <h1 style="margin:0 0 1rem;font-size:1.5rem">ただいまメンテナンス中です</h1>
+      <p style="margin:0;line-height:1.75">ご不便をおかけして申し訳ありません。しばらくしてから再度お試しください。</p>
+    </main>
+  </body>
+</html>`,
+    {
+      status: 503,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "retry-after": "3600",
+        "x-robots-tag": "noindex, nofollow",
+      },
+    }
+  );
+}
+
+export function middleware(_request: NextRequest): NextResponse {
+  if (!isMaintenanceModeEnabled()) {
+    return NextResponse.next();
+  }
+
+  return createMaintenanceResponse();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|api/cron/).*)",
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
 function isMaintenanceModeEnabled(): boolean {
   return process.env.MAINTENANCE_MODE === "true";
@@ -32,7 +32,7 @@ function createMaintenanceResponse(): NextResponse {
   );
 }
 
-export function middleware(_request: NextRequest): NextResponse {
+export function middleware(): NextResponse {
   if (!isMaintenanceModeEnabled()) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## 概要

Vercel上でアプリケーションを一時的に公開停止できるメンテナンスモードを追加します。

## 変更内容

- `MAINTENANCE_MODE=true` のとき、通常の画面およびAPIにHTTP 503のメンテナンス画面を返す
- `Retry-After` と検索エンジン向けのnoindexヘッダーを設定
- `/api/cron/*` と静的アセットは対象外とし、定期削除処理とメンテナンス画面の表示を維持

## 利用方法

1. VercelのEnvironment Variablesで`MAINTENANCE_MODE=true`をProductionに設定する
2. 本番を再デプロイする
3. 再開時は`MAINTENANCE_MODE=false`に変更して再デプロイする

## 確認

- GitHub上で追加した`src/middleware.ts`とコミット差分を確認
- ローカルのチェックアウトとnpm依存関係がこの実行環境にないため、`npm run lint`は未実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 環境設定により、サイト全体をメンテナンスモードへ切り替えられるようになりました。
  * メンテナンス中は専用画面を表示し、検索エンジンへの登録を抑制します。
  * 静的ファイルや一部のシステム処理は、メンテナンス中も通常どおり利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->