### PR TITLE
[一覧画面] 2週間より前のレース日を日付選択欄から除外する

### DIFF
--- a/src/app/api/races/dates/route.ts
+++ b/src/app/api/races/dates/route.ts
@@ -5,11 +5,18 @@ const prisma = new PrismaClient();
 
 export async function GET() {
   try {
+    // 2週間より前の開催日は日付選択欄に表示しない。
+    // 14日前の日付と未来の開催日は表示対象に含める。
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setUTCHours(0, 0, 0, 0);
+    twoWeeksAgo.setUTCDate(twoWeeksAgo.getUTCDate() - 14);
+
     // レースが存在する日付の一覧を取得（重複なし、降順）
     const raceDates = await prisma.race.findMany({
       where: {
         race_time: {
           not: null,
+          gte: twoWeeksAgo,
         },
       },
       select: {


### PR DESCRIPTION
## 概要

Issue #42に対応し、一覧画面右側の日付選択欄に表示する開催日を直近2週間分に限定します。

## 変更内容

- `/api/races/dates` の取得条件に14日前の日付を下限として追加
- 14日前の日付と未来の開催日は表示対象に含める
- 2週間より前の開催日は日付選択欄に表示しない

## 変更範囲

- `src/app/api/races/dates/route.ts`

## 検証

- ブランチ上のファイル内容とコミット差分を確認済み
- 自動テストは、リポジトリに該当するテストスクリプトおよびCI設定がないため未実行

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * レース開催日の取得対象を、UTC基準で14日前から将来の日付までに限定しました。
  * 14日前の日付も取得対象に含まれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->