### PR TITLE
サーバー側の相対APIリクエストをPrismaの直接クエリに置き換える

### DIFF
--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Race, Entry, Predict, Result, Payout, RecommendedBet } from "@prisma/cl
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
 import { formatInTimeZone } from "date-fns-tz"
+import { prisma } from "@/lib/prisma"
 
 function getCombinedAccentClass(courseType: string, track: string): string {
   const courseAccent = getCourseAccentClass(courseType)
@@ -56,24 +57,53 @@ type RaceWithEntriesAndPredicts = Race & {
 }
 
 
-async function getRaceWithEntries(id: number): Promise<RaceWithEntriesAndPredicts> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/races/${id}`, { cache: 'no-store' });
-  if (!res.ok) {
-    throw new Error('Failed to fetch race');
-  }
-  return res.json();
+async function getRaceWithEntries(id: number): Promise<RaceWithEntriesAndPredicts | null> {
+  return prisma.race.findFirst({
+    where: { id },
+    include: {
+      entries: {
+        include: {
+          HorseMaster: true,
+          JockeyMaster: true,
+        },
+      },
+      predicts: true,
+      results: true,
+      payouts: true,
+      recommended_bets: true,
+    },
+  })
 }
 
 async function getNavigation(id: number): Promise<{ prevRaceId?: number; nextRaceId?: number }> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/races/${id}/navigation`, { cache: "no-store" })
-  if (!res.ok) {
-    throw new Error("Failed to fetch navigation")
+  const currentRace = await prisma.race.findUnique({
+    where: { id },
+    select: { race_time: true },
+  })
+
+  if (!currentRace?.race_time) {
+    return {}
   }
-  return res.json()
+
+  const [prevRace, nextRace] = await Promise.all([
+    prisma.race.findFirst({
+      where: { race_time: { lt: currentRace.race_time } },
+      orderBy: { race_time: "desc" },
+      select: { id: true },
+    }),
+    prisma.race.findFirst({
+      where: { race_time: { gt: currentRace.race_time } },
+      orderBy: { race_time: "asc" },
+      select: { id: true },
+    }),
+  ])
+
+  return { prevRaceId: prevRace?.id, nextRaceId: nextRace?.id }
 }
 
-export default async function RacePage({ params }: { params: Promise<{ id: number }> }) {
-  const { id } = await params;
+export default async function RacePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params
+  const id = Number(idParam)
   const [race, navigation] = await Promise.all([getRaceWithEntries(id), getNavigation(id)])
 
 
@@ -120,4 +150,3 @@ export default async function RacePage({ params }: { params: Promise<{ id: numbe
     </main>
   )
 }
-

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from "@prisma/client"
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma
+}


### PR DESCRIPTION
目的
サーバーレンダリングされるページから相対URLの /api/races/... を fetch した際に発生する ERR_INVALID_URL を解消します。

サーバー内部で不要なHTTPリクエストを行わず、Prismaを使用してレース情報を直接取得するようにします。

開発時のホットリロードによって複数の PrismaClient インスタンスが生成されることを防ぎます。

変更内容
src/lib/prisma.ts を追加し、開発環境で再利用される共通のPrismaクライアントを定義しました。 

src/app/races/[id]/page.tsx から共通のPrismaクライアントを利用するようにしました。 

レース詳細取得時のサーバー側 fetch を廃止し、関連する出走情報、予想、結果、払戻、推奨馬券をPrismaで直接取得するようにしました。 

前後のレース情報についても、APIへのHTTPリクエストではなくPrismaで直接取得するようにしました。 

動的ルートのパラメーターを文字列として受け取り、Prismaの検索に使用する前に数値へ変換するようにしました。 

対象レースまたはレース日時が存在しない場合は、前後レースの情報として空のオブジェクトを返すようにしました。 

マイグレーションへの影響
Prismaスキーマおよびデータベースマイグレーションの変更はありません。

画面への影響
見た目や画面構成の変更はありません。

/races/[id] のサーバー側データ取得方法のみを変更しています。

UI変更ではないため、スクリーンショットはありません。

確認内容
ERR_INVALID_URL の原因となっていたサーバー側の相対URLによる fetch が削除されていることを確認しました。

ESLintおよびTypeScriptの型チェックが成功することを確認しました。

差分に空白エラーがないことを確認しました。

確認コマンド

✅ npx eslint src/app/races/'[id]'/page.tsx src/lib/prisma.ts

✅ npx tsc --noEmit

✅ git diff --check

⚠️ npm run lint — インストールされているNext.jsでは next lint が利用できず、lint がプロジェクトディレクトリとして解釈されるため実行できませんでした。

今回は提示された差分にインラインコメントが含まれておらず、作業ツリーにも未コミットの変更がなかったため、追加のコード変更、コミット、PR作成は行っていません。確認には git status --short と git log -1 --oneline を使用しました。