### PR TITLE
予想印と予想順位・数値表示を削除する (#47)

### DIFF
--- a/src/app/components/EntryTable.tsx
+++ b/src/app/components/EntryTable.tsx
@@ -1,8 +1,7 @@
 import React from "react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/app/components/ui/table"
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card"
-import { Entry, Predict } from "@prisma/client"
-import { useMemo } from "react"
+import { Entry } from "@prisma/client"
 import { groupBy } from "lodash"
 
 type EntryWithMasters = Entry & {
@@ -12,25 +11,13 @@ type EntryWithMasters = Entry & {
 
 type Props = {
   entries: EntryWithMasters[]
-  predicts: Predict[]
 }
 
 const sortByHorseNumber = (a: EntryWithMasters, b: EntryWithMasters) => {
   return a.horse_number - b.horse_number
 }
 
-export function EntryTable({ entries, predicts }: Props) {
-  const predictMarks = useMemo(() => {
-    const sortedPredicts = [...predicts].sort((a, b) => b.score - a.score)
-    const marks = ["◎", "○", "▲", "△", "×"]
-    return new Map(
-      sortedPredicts.map((predict, index) => [
-        predict.horse_number,
-        index < marks.length ? marks[index] : "×"
-      ])
-    )
-  }, [predicts])
-
+export function EntryTable({ entries }: Props) {
   // 枠番でグループ化し、各グループ内で馬番順にソート
   const groupedEntries = Object.entries(groupBy(entries, "bracket_number"))
     .map(([bracketNumber, entriesInBracket]) => ({
@@ -55,7 +42,6 @@ export function EntryTable({ entries, predicts }: Props) {
               <TableHead>馬齢</TableHead>
               <TableHead>騎手</TableHead>
               <TableHead>負担重量</TableHead>
-              <TableHead>予想印</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -74,7 +60,6 @@ export function EntryTable({ entries, predicts }: Props) {
                     <TableCell>{entry.age}</TableCell>
                     <TableCell>{entry.JockeyMaster?.name ?? "不明"}</TableCell>
                     <TableCell>{entry.jockey_weight}</TableCell>
-                    <TableCell>{predictMarks.get(entry.horse_number) ?? "×"}</TableCell>
                   </TableRow>
                 ))}
               </React.Fragment>

--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent } from "@/app/components/ui/card"
 import { EntryTable } from "@/app/components/EntryTable"
 import { RaceResultTable } from "@/app/components/RaceResultTable"
 import { PayoutTable } from "@/app/components/PayoutTable"
-import { Race, Entry, Predict, Result, Payout, RecommendedBet } from "@prisma/client"
+import { Race, Entry, Result, Payout, RecommendedBet } from "@prisma/client"
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
 import { formatInTimeZone } from "date-fns-tz"
@@ -48,16 +48,15 @@ type EntryWithMasters = Entry & {
   JockeyMaster: { name: string }
 }
 
-type RaceWithEntriesAndPredicts = Race & {
+type RaceWithEntries = Race & {
   entries: EntryWithMasters[]
-  predicts: Predict[]
   results: Result[]
   payouts: Payout[]
   recommended_bets: RecommendedBet[]
 }
 
 
-async function getRaceWithEntries(id: number): Promise<RaceWithEntriesAndPredicts | null> {
+async function getRaceWithEntries(id: number): Promise<RaceWithEntries | null> {
   return prisma.race.findFirst({
     where: { id },
     include: {
@@ -67,7 +66,6 @@ async function getRaceWithEntries(id: number): Promise<RaceWithEntriesAndPredict
           JockeyMaster: true,
         },
       },
-      predicts: true,
       results: true,
       payouts: true,
       recommended_bets: true,
@@ -132,7 +130,7 @@ export default async function RacePage({ params }: { params: Promise<{ id: strin
           </div>
         </CardContent>
       </Card>
-      <EntryTable entries={race.entries} predicts={race.predicts} />
+      <EntryTable entries={race.entries} />
       <RecommendedBets bets={race.recommended_bets} entries={race.entries} />
       <div className="mt-6 flex flex-col lg:flex-row gap-6">
         {race.results && race.results.length > 0 && (


### PR DESCRIPTION
## 概要

Closes #47 (親Issue #43)

レース詳細画面の出馬表から予想印（◎・○・▲・△・×）を削除する。

## 変更内容

- `EntryTable` から `Predict.score` の順位で予想印を生成する処理と「予想印」列を削除
- レース詳細ページで `predicts` を取得・受け渡ししないように変更
- 既存の出馬表情報（枠番・馬番・馬名・性別・馬齢・騎手・負担重量）は維持
- `Predict` テーブルのデータ自体は将来の分析用途のため保持（削除しない）

## スタックPR

このPRは #43 の子Issueを分割した5本のスタックPRの1本目。

1. **#47 予想印削除（本PR / base: `main`）**
2. #46 AI指標ラベルのデータ契約
3. #48 AI指標ラベルのバッジ表示
4. #49 AI予想コメントのデータ取得契約
5. #50 AI予想コメントの表示

## 検証

- `npm run lint` / `npx tsc --noEmit` パス
- ローカルでレース詳細画面を表示し、◎○▲△×が表示されないことを確認

## マイグレーション影響

なし