### PR TITLE
馬ごとのAI指標ラベルのデータ契約を追加する (#46)

### DIFF
--- a/prisma/migrations/20260815010000_add_horse_indicator/migration.sql
+++ b/prisma/migrations/20260815010000_add_horse_indicator/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "HorseIndicator" (
+    "id" SERIAL NOT NULL,
+    "netkeiba_race_id" VARCHAR NOT NULL,
+    "horse_number" SMALLINT NOT NULL,
+    "horse_id" VARCHAR,
+    "horse_name" TEXT,
+    "base_ability" DOUBLE PRECISION,
+    "condition_fit" DOUBLE PRECISION,
+    "pace_fit" DOUBLE PRECISION,
+    "freshness" DOUBLE PRECISION,
+    "history_count" INTEGER NOT NULL DEFAULT 0,
+    "rank" INTEGER,
+    "positive_factors" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "risks" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "warnings" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "expected_pace" VARCHAR,
+    "logic_version" VARCHAR,
+    "is_partial" BOOLEAN NOT NULL DEFAULT false,
+    "generated_at" TIMESTAMPTZ(6),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "HorseIndicator_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "horse_indicator_race_horse_number_key" ON "HorseIndicator"("netkeiba_race_id", "horse_number");
+
+-- AddForeignKey
+ALTER TABLE "HorseIndicator" ADD CONSTRAINT "fk_horse_indicator_netkeiba_race_id" FOREIGN KEY ("netkeiba_race_id") REFERENCES "Race"("netkeiba_race_id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,10 +72,39 @@ model Race {
   updated_at       DateTime         @default(now()) @db.Timestamptz(6)
   race_time        DateTime?        @db.Timestamp(6)
   entries          Entry[]
+  horse_indicators HorseIndicator[]
   payouts          Payout[]
   predicts         Predict[]
   recommended_bets RecommendedBet[]
   results          Result[]
+}
+
+/// horecast-predictor の事前バッチが保存する馬ごとの raw 指標。
+/// スコアはレース内相対値のため、レース間の比較には使用しない。
+model HorseIndicator {
+  id               Int       @id @default(autoincrement())
+  netkeiba_race_id String    @db.VarChar
+  horse_number     Int       @db.SmallInt
+  horse_id         String?   @db.VarChar
+  horse_name       String?
+  base_ability     Float?
+  condition_fit    Float?
+  pace_fit         Float?
+  freshness        Float?
+  history_count    Int       @default(0)
+  rank             Int?
+  positive_factors String[]  @default([])
+  risks            String[]  @default([])
+  warnings         String[]  @default([])
+  expected_pace    String?   @db.VarChar
+  logic_version    String?   @db.VarChar
+  is_partial       Boolean   @default(false)
+  generated_at     DateTime? @db.Timestamptz(6)
+  created_at       DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at       DateTime  @default(now()) @db.Timestamptz(6)
+  Race             Race      @relation(fields: [netkeiba_race_id], references: [netkeiba_race_id], onDelete: Cascade, onUpdate: NoAction, map: "fk_horse_indicator_netkeiba_race_id")
+
+  @@unique([netkeiba_race_id, horse_number], map: "horse_indicator_race_horse_number_key")
 }
 
 model Result {

--- a/src/app/lib/horseIndicators.ts
+++ b/src/app/lib/horseIndicators.ts
@@ -1,0 +1,56 @@
+import { HorseIndicator } from "@prisma/client"
+import { prisma } from "@/lib/prisma"
+import { HorseIndicatorLabels, toHorseIndicatorLabels } from "@/app/lib/indicatorLabels"
+
+export type HorseIndicatorLabelsResult = {
+  /** 馬番順の表示用ラベル。未生成・取得失敗時は空配列 */
+  indicators: HorseIndicatorLabels[]
+  /** 表示対象とした生成バージョン */
+  logicVersion: string | null
+}
+
+const EMPTY_RESULT: HorseIndicatorLabelsResult = { indicators: [], logicVersion: null }
+
+function generatedTime(indicator: HorseIndicator): number {
+  return (indicator.generated_at ?? indicator.created_at).getTime()
+}
+
+/**
+ * 生成バージョンが混在しないよう、最新の logic_version の行だけを表示対象にする。
+ */
+function pickLatestLogicVersion(indicators: HorseIndicator[]): HorseIndicator[] {
+  if (indicators.length === 0) {
+    return indicators
+  }
+
+  const latest = indicators.reduce((newest, indicator) =>
+    generatedTime(indicator) > generatedTime(newest) ? indicator : newest
+  )
+
+  return indicators.filter((indicator) => indicator.logic_version === latest.logic_version)
+}
+
+/**
+ * 出馬表に表示する馬ごとのAI指標ラベルを取得する。
+ * 指標が未生成、あるいは取得に失敗してもレース詳細画面を落とさず、ラベル無しとして扱う。
+ */
+export async function getHorseIndicatorLabels(
+  netkeibaRaceId: string
+): Promise<HorseIndicatorLabelsResult> {
+  try {
+    const indicators = await prisma.horseIndicator.findMany({
+      where: { netkeiba_race_id: netkeibaRaceId },
+    })
+    const targets = pickLatestLogicVersion(indicators)
+
+    return {
+      indicators: targets
+        .map(toHorseIndicatorLabels)
+        .sort((a, b) => a.horseNumber - b.horseNumber),
+      logicVersion: targets[0]?.logic_version ?? null,
+    }
+  } catch (error) {
+    console.error("Failed to fetch horse indicators", error)
+    return EMPTY_RESULT
+  }
+}

--- a/src/app/lib/indicatorLabels.ts
+++ b/src/app/lib/indicatorLabels.ts
@@ -1,0 +1,103 @@
+/**
+ * horecast-predictor が保存した raw 指標（HorseIndicator）を、
+ * 画面表示用のラベルへ変換する。
+ *
+ * - スコアはレース内相対値（同値は 50）であり、レース間比較には使わない
+ * - 指標を算出できない場合は「標準」ではなく「判断材料不足」とする
+ * - UI 側ではスコアを再計算せず、ここで生成したラベルだけを表示する
+ */
+
+export const INSUFFICIENT_LABEL = "判断材料不足"
+
+/** 地力：base_ability / ability_score */
+const ABILITY_LABELS = ["最上位", "上位", "標準", "やや下位", "下位"] as const
+/** 条件適性：condition_fit / fitness_score */
+const CONDITION_LABELS = ["高い", "やや高い", "標準", "やや不安", "不安"] as const
+/** 展開適性：pace_fit / pace_score */
+const PACE_LABELS = ["展開有利", "やや有利", "中立", "やや不利", "展開不利"] as const
+/** 近走状態：freshness（算出不可は判断材料不足） */
+const FRESHNESS_LABELS = ["好調", "安定", "平行線", "やや不安"] as const
+
+/** 上位から順に区切るしきい値。50（同値）は中央のラベルへ入る */
+const FIVE_LEVEL_THRESHOLDS = [80, 60, 40, 20]
+const FOUR_LEVEL_THRESHOLDS = [75, 55, 35]
+
+export type IndicatorLabel = {
+  label: string
+  /** バッジの配色用。0 が最上位、値が大きいほど下位。判断材料不足は null */
+  level: number | null
+}
+
+export type HorseIndicatorLabels = {
+  horseNumber: number
+  /** 地力 */
+  ability: IndicatorLabel
+  /** 条件適性 */
+  conditionFit: IndicatorLabel
+  /** 展開適性 */
+  paceFit: IndicatorLabel
+  /** 近走状態 */
+  freshness: IndicatorLabel
+  /** 4指標すべてが算出不可 */
+  isInsufficient: boolean
+}
+
+/** 変換元となる raw 指標。predictor 側の保存契約に対応する */
+export type HorseIndicatorSource = {
+  horse_number: number
+  base_ability: number | null
+  condition_fit: number | null
+  pace_fit: number | null
+  freshness: number | null
+  history_count?: number | null
+}
+
+const insufficient = (): IndicatorLabel => ({ label: INSUFFICIENT_LABEL, level: null })
+
+function toLabel(
+  score: number | null | undefined,
+  labels: readonly string[],
+  thresholds: number[]
+): IndicatorLabel {
+  if (score === null || score === undefined || Number.isNaN(score)) {
+    return insufficient()
+  }
+  const index = thresholds.findIndex((threshold) => score >= threshold)
+  const level = index === -1 ? labels.length - 1 : index
+  return { label: labels[level], level }
+}
+
+export function toHorseIndicatorLabels(
+  indicator: HorseIndicatorSource
+): HorseIndicatorLabels {
+  // 履歴が一件も無い馬は、スコアが入っていても評価材料が無いものとして扱う
+  const hasHistory = indicator.history_count === null || indicator.history_count === undefined
+    ? true
+    : indicator.history_count > 0
+
+  const ability = hasHistory
+    ? toLabel(indicator.base_ability, ABILITY_LABELS, FIVE_LEVEL_THRESHOLDS)
+    : insufficient()
+  const conditionFit = hasHistory
+    ? toLabel(indicator.condition_fit, CONDITION_LABELS, FIVE_LEVEL_THRESHOLDS)
+    : insufficient()
+  const paceFit = hasHistory
+    ? toLabel(indicator.pace_fit, PACE_LABELS, FIVE_LEVEL_THRESHOLDS)
+    : insufficient()
+  const freshness = hasHistory
+    ? toLabel(indicator.freshness, FRESHNESS_LABELS, FOUR_LEVEL_THRESHOLDS)
+    : insufficient()
+
+  return {
+    horseNumber: indicator.horse_number,
+    ability,
+    conditionFit,
+    paceFit,
+    freshness,
+    isInsufficient:
+      ability.level === null &&
+      conditionFit.level === null &&
+      paceFit.level === null &&
+      freshness.level === null,
+  }
+}


### PR DESCRIPTION
## 概要

Closes #46 (親Issue #43)

horecast-predictor が事前バッチで保存する `HorseIndicator` を参照し、raw 指標を表示用ラベルへ変換する取得層を追加する。UI 側でスコアを再計算しない構成にする。

## 変更内容

- `prisma/schema.prisma` に `HorseIndicator` モデルを追加（predictor #153 の保存契約に対応）
  - upsertキー: `netkeiba_race_id` + `horse_number`
  - `base_ability` / `condition_fit` / `pace_fit` / `freshness` / `history_count` / `rank` / `logic_version` / `is_partial` など
- マイグレーション `20260815010000_add_horse_indicator` を追加
- `src/app/lib/indicatorLabels.ts`: raw 指標 → 表示ラベル変換
  - 地力: 最上位 / 上位 / 標準 / やや下位 / 下位
  - 条件適性: 高い / やや高い / 標準 / やや不安 / 不安
  - 展開適性: 展開有利 / やや有利 / 中立 / やや不利 / 展開不利
  - 近走状態: 好調 / 安定 / 平行線 / やや不安 / 判断材料不足
- `src/app/lib/horseIndicators.ts`: レース単位の取得層

## 設計上のポイント

- スコアはレース内相対値（同値=50）のため、しきい値は 50 を中心に対称（80 / 60 / 40 / 20）
- 指標が null、または `history_count = 0` の場合は「標準」ではなく **「判断材料不足」** を返す
- `logic_version` が混在しないよう、最新の生成バージョンの行のみを表示対象にする
- テーブル未作成・取得失敗時は空の結果を返し、レース詳細画面を落とさない（`try/catch`）

## スタックPR

- base: `feature/47-remove-predict-marks`（#47）
- このPRの上に #48 が積まれる

## 検証

- `npm run lint` / `npx tsc --noEmit` パス
- しきい値の境界値（0/19/20/40/50/60/80/100、null、history_count=0）を実行して期待ラベルを確認
- `HorseIndicator` テーブルが存在しない状態でもレース詳細画面が 200 で表示されることを確認

## マイグレーション影響

`prisma/migrations/20260815010000_add_horse_indicator` を追加。新規テーブルのみで既存テーブルの変更はなし。predictor 側の書き込み先となる。