### PR TITLE
出馬表にAI指標ラベルをバッジ表示する (#48)

### DIFF
--- a/src/app/components/EntryTable.tsx
+++ b/src/app/components/EntryTable.tsx
@@ -1,8 +1,10 @@
 import React from "react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/app/components/ui/table"
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card"
+import { Badge } from "@/app/components/ui/badge"
 import { Entry } from "@prisma/client"
 import { groupBy } from "lodash"
+import { HorseIndicatorLabels, IndicatorLabel, INSUFFICIENT_LABEL } from "@/app/lib/indicatorLabels"
 
 type EntryWithMasters = Entry & {
   HorseMaster: { name: string }
@@ -11,13 +13,52 @@ type EntryWithMasters = Entry & {
 
 type Props = {
   entries: EntryWithMasters[]
+  indicators?: HorseIndicatorLabels[]
 }
 
 const sortByHorseNumber = (a: EntryWithMasters, b: EntryWithMasters) => {
   return a.horse_number - b.horse_number
 }
 
-export function EntryTable({ entries }: Props) {
+/** 上位ほど暖色、下位ほど寒色。判断材料不足は無彩色 */
+const LEVEL_CLASSES = [
+  "bg-red-50 text-red-700 border-red-200",
+  "bg-orange-50 text-orange-700 border-orange-200",
+  "bg-gray-50 text-gray-700 border-gray-200",
+  "bg-sky-50 text-sky-700 border-sky-200",
+  "bg-slate-100 text-slate-500 border-slate-200",
+]
+const INSUFFICIENT_CLASS = "bg-gray-100 text-gray-500 border-dashed border-gray-300"
+
+function IndicatorBadge({ name, indicator }: { name: string; indicator: IndicatorLabel }) {
+  const toneClass = indicator.level === null ? INSUFFICIENT_CLASS : LEVEL_CLASSES[indicator.level]
+  return (
+    <Badge variant="outline" className={`whitespace-nowrap font-medium ${toneClass}`}>
+      {name}：{indicator.label}
+    </Badge>
+  )
+}
+
+function IndicatorBadges({ labels }: { labels?: HorseIndicatorLabels }) {
+  if (!labels || labels.isInsufficient) {
+    return (
+      <Badge variant="outline" className={`whitespace-nowrap font-medium ${INSUFFICIENT_CLASS}`}>
+        {INSUFFICIENT_LABEL}
+      </Badge>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      <IndicatorBadge name="地力" indicator={labels.ability} />
+      <IndicatorBadge name="条件適性" indicator={labels.conditionFit} />
+      <IndicatorBadge name="展開適性" indicator={labels.paceFit} />
+      <IndicatorBadge name="近走状態" indicator={labels.freshness} />
+    </div>
+  )
+}
+
+export function EntryTable({ entries, indicators = [] }: Props) {
   // 枠番でグループ化し、各グループ内で馬番順にソート
   const groupedEntries = Object.entries(groupBy(entries, "bracket_number"))
     .map(([bracketNumber, entriesInBracket]) => ({
@@ -26,13 +67,18 @@ export function EntryTable({ entries }: Props) {
     }))
     .sort((a, b) => a.bracketNumber - b.bracketNumber)
 
+  const indicatorMap = new Map(indicators.map((indicator) => [indicator.horseNumber, indicator]))
+  // 指標が1件も無いレースでは列そのものを表示しない
+  const hasIndicators = indicators.length > 0
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>出馬表</CardTitle>
       </CardHeader>
       <CardContent>
-        <Table>
+        {/* 指標列が増える分、狭い画面ではテーブルを潰さず横スクロールさせる */}
+        <Table className={hasIndicators ? "min-w-[760px]" : undefined}>
           <TableHeader>
             <TableRow>
               <TableHead className="align-middle text-center">枠番</TableHead>
@@ -42,6 +88,7 @@ export function EntryTable({ entries }: Props) {
               <TableHead>馬齢</TableHead>
               <TableHead>騎手</TableHead>
               <TableHead>負担重量</TableHead>
+              {hasIndicators && <TableHead className="min-w-[240px]">AI指標</TableHead>}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -55,11 +102,16 @@ export function EntryTable({ entries }: Props) {
                       </TableCell>
                     )}
                     <TableCell>{entry.horse_number}</TableCell>
-                    <TableCell>{entry.HorseMaster?.name ?? "不明"}</TableCell>
+                    <TableCell className="whitespace-nowrap">{entry.HorseMaster?.name ?? "不明"}</TableCell>
                     <TableCell>{entry.sex}</TableCell>
                     <TableCell>{entry.age}</TableCell>
-                    <TableCell>{entry.JockeyMaster?.name ?? "不明"}</TableCell>
+                    <TableCell className="whitespace-nowrap">{entry.JockeyMaster?.name ?? "不明"}</TableCell>
                     <TableCell>{entry.jockey_weight}</TableCell>
+                    {hasIndicators && (
+                      <TableCell className="min-w-[240px]">
+                        <IndicatorBadges labels={indicatorMap.get(entry.horse_number)} />
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))}
               </React.Fragment>
@@ -70,4 +122,3 @@ export function EntryTable({ entries }: Props) {
     </Card>
   )
 }
-

--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -7,6 +7,7 @@ import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
 import { formatInTimeZone } from "date-fns-tz"
 import { prisma } from "@/lib/prisma"
+import { getHorseIndicatorLabels } from "@/app/lib/horseIndicators"
 
 function getCombinedAccentClass(courseType: string, track: string): string {
   const courseAccent = getCourseAccentClass(courseType)
@@ -108,6 +109,7 @@ export default async function RacePage({ params }: { params: Promise<{ id: strin
   if (!race) {
     return <div>レースが見つかりません</div>
   }
+  const { indicators } = await getHorseIndicatorLabels(race.netkeiba_race_id)
   const raceTime = race.race_time ? new Date(race.race_time) : null
   const formattedDate = raceTime
     ? formatInTimeZone(raceTime, 'UTC', 'yyyy年M月d日')
@@ -130,7 +132,7 @@ export default async function RacePage({ params }: { params: Promise<{ id: strin
           </div>
         </CardContent>
       </Card>
-      <EntryTable entries={race.entries} />
+      <EntryTable entries={race.entries} indicators={indicators} />
       <RecommendedBets bets={race.recommended_bets} entries={race.entries} />
       <div className="mt-6 flex flex-col lg:flex-row gap-6">
         {race.results && race.results.length > 0 && (


### PR DESCRIPTION
## 概要

Closes #48 (親Issue #43)

出馬表の各馬の行に、AI指標ラベルをバッジ形式で表示する。

## 変更内容

- `EntryTable` に「AI指標」列を追加し、地力・条件適性・展開適性・近走状態をバッジ表示
- レース詳細ページで `getHorseIndicatorLabels` を呼び、ラベルを `EntryTable` へ渡す
- 上位ほど暖色、下位ほど寒色、判断材料不足は無彩色（破線）で配色
- 指標が算出できない馬は「判断材料不足」バッジを1つだけ表示
- 指標が1件も無いレースでは AI指標 列自体を表示しない
- 列が増える分、狭い画面ではテーブルを潰さず横スクロールさせる（`min-w-[760px]` + 馬名・騎手の `whitespace-nowrap`）

## 表示ルールの遵守

- スコア・順位・複勝率・出走数などの数値は表示しない
- UIは数値を再計算せず、#46 の取得層が返したラベルのみを描画する

## スタックPR

- base: `feature/46-horse-indicator-contract`（#46）
- このPRの上に #49 / #50 が積まれる

## 検証

- `npm run lint` / `npx tsc --noEmit` パス
- ローカルでモックデータを流し、5段階すべて + 判断材料不足の表示を確認
- 1280px: テーブル幅 1230px でぴったり収まり横スクロールなし、行高 39px
- 375px（モバイル）: `document.scrollWidth == clientWidth`（ページ自体は横スクロールしない）、テーブルカード内のみ横スクロール、馬名が縦積みにならないことを確認
- 指標データが無い場合に AI指標 列が出ず、レイアウトが従来どおりであることを確認

## マイグレーション影響

なし（#46 のマイグレーションを含む）