### PR TITLE
レース全体AI予想コメントのデータ取得契約を追加する (#49)

### DIFF
--- a/prisma/migrations/20260815020000_add_race_prediction_comment/migration.sql
+++ b/prisma/migrations/20260815020000_add_race_prediction_comment/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "RacePredictionComment" (
+    "id" SERIAL NOT NULL,
+    "netkeiba_race_id" VARCHAR NOT NULL,
+    "provider" VARCHAR NOT NULL,
+    "model_id" VARCHAR,
+    "comment" TEXT NOT NULL,
+    "caveat" TEXT,
+    "warnings" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "logic_version" VARCHAR,
+    "prompt_version" VARCHAR NOT NULL DEFAULT '',
+    "is_partial" BOOLEAN NOT NULL DEFAULT false,
+    "source_generated_at" TIMESTAMPTZ(6),
+    "generated_at" TIMESTAMPTZ(6),
+    "openai_batch_id" VARCHAR,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RacePredictionComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "race_prediction_comment_race_provider_prompt_key" ON "RacePredictionComment"("netkeiba_race_id", "provider", "prompt_version");
+
+-- AddForeignKey
+ALTER TABLE "RacePredictionComment" ADD CONSTRAINT "fk_race_prediction_comment_netkeiba_race_id" FOREIGN KEY ("netkeiba_race_id") REFERENCES "Race"("netkeiba_race_id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,12 +71,36 @@ model Race {
   created_at       DateTime         @default(now()) @db.Timestamptz(6)
   updated_at       DateTime         @default(now()) @db.Timestamptz(6)
   race_time        DateTime?        @db.Timestamp(6)
-  entries          Entry[]
-  horse_indicators HorseIndicator[]
-  payouts          Payout[]
-  predicts         Predict[]
-  recommended_bets RecommendedBet[]
-  results          Result[]
+  entries             Entry[]
+  horse_indicators    HorseIndicator[]
+  payouts             Payout[]
+  predicts            Predict[]
+  prediction_comments RacePredictionComment[]
+  recommended_bets    RecommendedBet[]
+  results             Result[]
+}
+
+/// horecast-predictor の事前バッチが保存するレース全体のLLM予想コメント。
+/// provider ごとに1件を表示する。
+model RacePredictionComment {
+  id                  Int       @id @default(autoincrement())
+  netkeiba_race_id    String    @db.VarChar
+  provider            String    @db.VarChar
+  model_id            String?   @db.VarChar
+  comment             String
+  caveat              String?
+  warnings            String[]  @default([])
+  logic_version       String?   @db.VarChar
+  prompt_version      String    @default("") @db.VarChar
+  is_partial          Boolean   @default(false)
+  source_generated_at DateTime? @db.Timestamptz(6)
+  generated_at        DateTime? @db.Timestamptz(6)
+  openai_batch_id     String?   @db.VarChar
+  created_at          DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at          DateTime  @default(now()) @db.Timestamptz(6)
+  Race                Race      @relation(fields: [netkeiba_race_id], references: [netkeiba_race_id], onDelete: Cascade, onUpdate: NoAction, map: "fk_race_prediction_comment_netkeiba_race_id")
+
+  @@unique([netkeiba_race_id, provider, prompt_version], map: "race_prediction_comment_race_provider_prompt_key")
 }
 
 /// horecast-predictor の事前バッチが保存する馬ごとの raw 指標。

--- a/src/app/lib/racePredictionComments.ts
+++ b/src/app/lib/racePredictionComments.ts
@@ -1,0 +1,74 @@
+import { RacePredictionComment } from "@prisma/client"
+import { prisma } from "@/lib/prisma"
+
+export type RacePredictionCommentView = {
+  provider: string
+  modelId: string | null
+  comment: string
+  caveat: string | null
+  warnings: string[]
+  isPartial: boolean
+  generatedAt: string | null
+}
+
+/**
+ * コメント取得の結果。取得失敗（error）と未生成（comments が空）を区別し、
+ * 失敗をレース詳細画面全体の失敗へ波及させない。
+ */
+export type RacePredictionCommentsResult =
+  | { status: "ok"; comments: RacePredictionCommentView[] }
+  | { status: "error"; comments: [] }
+
+function generatedTime(comment: RacePredictionComment): number {
+  return (comment.generated_at ?? comment.created_at).getTime()
+}
+
+/**
+ * 同一プロバイダーで prompt_version 違いの行がある場合は、最新の生成結果だけを表示する。
+ */
+function pickLatestPerProvider(comments: RacePredictionComment[]): RacePredictionComment[] {
+  const latestByProvider = new Map<string, RacePredictionComment>()
+
+  comments.forEach((comment) => {
+    const current = latestByProvider.get(comment.provider)
+    if (!current || generatedTime(comment) > generatedTime(current)) {
+      latestByProvider.set(comment.provider, comment)
+    }
+  })
+
+  return Array.from(latestByProvider.values()).sort((a, b) =>
+    a.provider.localeCompare(b.provider)
+  )
+}
+
+function toView(comment: RacePredictionComment): RacePredictionCommentView {
+  return {
+    provider: comment.provider,
+    modelId: comment.model_id,
+    comment: comment.comment,
+    caveat: comment.caveat,
+    warnings: comment.warnings,
+    isPartial: comment.is_partial,
+    generatedAt: (comment.generated_at ?? comment.created_at).toISOString(),
+  }
+}
+
+/**
+ * レース全体のLLM予想コメントをプロバイダー単位で取得する。
+ * 新しいプロバイダーが増えても取得側の変更は不要。
+ */
+export async function getRacePredictionComments(
+  netkeibaRaceId: string
+): Promise<RacePredictionCommentsResult> {
+  try {
+    const comments = await prisma.racePredictionComment.findMany({
+      where: { netkeiba_race_id: netkeibaRaceId },
+    })
+
+    // 未生成の場合も成功として空配列を返す（画面側で「予想データなし」を表示する）
+    return { status: "ok", comments: pickLatestPerProvider(comments).map(toView) }
+  } catch (error) {
+    console.error("Failed to fetch race prediction comments", error)
+    return { status: "error", comments: [] }
+  }
+}


### PR DESCRIPTION
## 概要

Closes #49 (親Issue #43)

horecast-predictor が事前バッチで保存する `RacePredictionComment` を参照し、レース全体のLLM予想コメントをプロバイダー単位で取得できるようにする。

## 変更内容

- `prisma/schema.prisma` に `RacePredictionComment` モデルを追加（predictor #152 の保存契約に対応）
  - `provider` / `model_id` / `comment` / `caveat` / `warnings` / `logic_version` / `prompt_version` / `source_generated_at` / `generated_at` / `is_partial` / `openai_batch_id`
  - upsertキー: `netkeiba_race_id` + `provider` + `prompt_version`
- マイグレーション `20260815020000_add_race_prediction_comment` を追加
- `src/app/lib/racePredictionComments.ts`: 取得層

## 契約

```ts
type RacePredictionCommentsResult =
  | { status: "ok"; comments: RacePredictionCommentView[] }
  | { status: "error"; comments: [] }
```

- **正常時**: プロバイダー別コメントの配列（provider 昇順）
- **未生成時**: `status: "ok"` + 空配列（画面側で「予想データなし」を表示）
- **取得失敗時**: `status: "error"` を返し、レース詳細画面全体は成功扱いにする
- 同一プロバイダーで `prompt_version` 違いの行がある場合は最新の生成結果のみ返す
- DBの snake_case を camelCase へ変換して返す

horecast 側から OpenAI API / AgentCore は呼び出さない。

## スタックPR

- base: `feature/48-indicator-badges`（#48）
- このPRの上に #50 が積まれる

## 検証

- `npm run lint` / `npx tsc --noEmit` パス

## マイグレーション影響

`prisma/migrations/20260815020000_add_race_prediction_comment` を追加。新規テーブルのみで既存テーブルの変更はなし。predictor 側の書き込み先となる。