### PR TITLE
レース全体AI予想コメントを出馬表下に表示する (#50)

### DIFF
--- a/src/app/components/RacePredictionComments.tsx
+++ b/src/app/components/RacePredictionComments.tsx
@@ -1,0 +1,132 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card"
+import { Badge } from "@/app/components/ui/badge"
+import { formatInTimeZone } from "date-fns-tz"
+import {
+  getRacePredictionComments,
+  RacePredictionCommentView,
+} from "@/app/lib/racePredictionComments"
+
+type Props = {
+  netkeibaRaceId: string
+}
+
+/**
+ * 表示名の対応が無いプロバイダーは識別子をそのまま表示する。
+ * 新しいLLMが増えてもUIの変更なしにカードが追加される。
+ */
+const PROVIDER_NAMES: Record<string, string> = {
+  openai: "OpenAI",
+  anthropic: "Claude",
+  claude: "Claude",
+  google: "Gemini",
+  gemini: "Gemini",
+}
+
+function providerName(provider: string): string {
+  return PROVIDER_NAMES[provider.toLowerCase()] ?? provider
+}
+
+function formatGeneratedAt(generatedAt: string | null): string | null {
+  if (!generatedAt) {
+    return null
+  }
+  const date = new Date(generatedAt)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  return formatInTimeZone(date, "Asia/Tokyo", "yyyy年M月d日 HH:mm")
+}
+
+function CommentsCard({ children }: { children: React.ReactNode }) {
+  return (
+    <Card className="mt-8 bg-white border border-gray-200 shadow-sm">
+      <CardHeader>
+        <CardTitle>AI予想コメント</CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  )
+}
+
+/** 取得中に表示するスケルトン */
+export function RacePredictionCommentsSkeleton() {
+  return (
+    <CommentsCard>
+      <div className="animate-pulse space-y-3" aria-label="AI予想コメントを読み込み中">
+        <div className="h-4 w-32 rounded bg-gray-200" />
+        <div className="h-3 w-full rounded bg-gray-200" />
+        <div className="h-3 w-11/12 rounded bg-gray-200" />
+        <div className="h-3 w-9/12 rounded bg-gray-200" />
+      </div>
+    </CommentsCard>
+  )
+}
+
+function ProviderComment({ comment }: { comment: RacePredictionCommentView }) {
+  const generatedAt = formatGeneratedAt(comment.generatedAt)
+
+  return (
+    <div className="flex flex-col bg-gray-100 p-4 rounded-lg border border-gray-200">
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        <h3 className="text-lg font-semibold">{providerName(comment.provider)}</h3>
+        {comment.modelId && (
+          <Badge variant="outline" className="text-gray-600">
+            {comment.modelId}
+          </Badge>
+        )}
+        {comment.isPartial && (
+          <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200">
+            材料少なめ
+          </Badge>
+        )}
+      </div>
+      <p className="flex-1 leading-relaxed whitespace-pre-wrap">{comment.comment}</p>
+      {comment.caveat && (
+        <p className="mt-3 pt-3 border-t text-sm text-gray-600 whitespace-pre-wrap">
+          {comment.caveat}
+        </p>
+      )}
+      {comment.warnings.length > 0 && (
+        <ul className="mt-2 space-y-1 text-sm text-gray-600">
+          {comment.warnings.map((warning) => (
+            <li key={warning}>{warning}</li>
+          ))}
+        </ul>
+      )}
+      {generatedAt && (
+        <p className="mt-3 text-xs text-gray-500 text-right">生成: {generatedAt}</p>
+      )}
+    </div>
+  )
+}
+
+export async function RacePredictionComments({ netkeibaRaceId }: Props) {
+  const result = await getRacePredictionComments(netkeibaRaceId)
+
+  if (result.status === "error") {
+    // 取得失敗はこの領域だけに閉じ込め、レース詳細画面は表示を続ける
+    return (
+      <CommentsCard>
+        <p className="text-center text-gray-600">AI予想コメントを取得できませんでした</p>
+      </CommentsCard>
+    )
+  }
+
+  if (result.comments.length === 0) {
+    return (
+      <CommentsCard>
+        <p className="text-center text-gray-600">予想データなし</p>
+      </CommentsCard>
+    )
+  }
+
+  return (
+    <CommentsCard>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {result.comments.map((comment) => (
+          <ProviderComment key={comment.provider} comment={comment} />
+        ))}
+      </div>
+    </CommentsCard>
+  )
+}

--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -5,9 +5,14 @@ import { PayoutTable } from "@/app/components/PayoutTable"
 import { Race, Entry, Result, Payout, RecommendedBet } from "@prisma/client"
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
+import {
+  RacePredictionComments,
+  RacePredictionCommentsSkeleton,
+} from "@/app/components/RacePredictionComments"
 import { formatInTimeZone } from "date-fns-tz"
 import { prisma } from "@/lib/prisma"
 import { getHorseIndicatorLabels } from "@/app/lib/horseIndicators"
+import { Suspense } from "react"
 
 function getCombinedAccentClass(courseType: string, track: string): string {
   const courseAccent = getCourseAccentClass(courseType)
@@ -133,6 +138,9 @@ export default async function RacePage({ params }: { params: Promise<{ id: strin
         </CardContent>
       </Card>
       <EntryTable entries={race.entries} indicators={indicators} />
+      <Suspense fallback={<RacePredictionCommentsSkeleton />}>
+        <RacePredictionComments netkeibaRaceId={race.netkeiba_race_id} />
+      </Suspense>
       <RecommendedBets bets={race.recommended_bets} entries={race.entries} />
       <div className="mt-6 flex flex-col lg:flex-row gap-6">
         {race.results && race.results.length > 0 && (


### PR DESCRIPTION
## 概要

Closes #50 (親Issue #43)

レース詳細画面の出馬表直下・推奨馬券の前に、レース全体のAI予想コメントをプロバイダー別カードで表示する。

## 変更内容

- `RacePredictionComments` コンポーネントを追加（Server Component）
- レース詳細ページで `<Suspense>` により出馬表と推奨馬券の間に配置
- プロバイダーごとにカードを分割（`lg` 以上で2カラム、モバイルは1カラム）
- `model_id`、`is_partial`（「材料少なめ」）、`caveat`、`warnings`、生成時刻を表示

## 状態ごとの表示

| 状態 | 表示 |
| --- | --- |
| 取得中 | スケルトン（`Suspense` fallback） |
| 未生成 | 「予想データなし」 |
| 取得失敗 | 「AI予想コメントを取得できませんでした」（コメント領域のみ） |
| 正常 | プロバイダー別カード |

## 拡張性

`PROVIDER_NAMES` に無い `provider` は識別子をそのまま表示するため、新しいLLMが増えてもUIの変更なしにカードが追加される。

## 表示順

```
レースヘッダー
出馬表（予想印なし、AI指標ラベルあり）
レース全体のAI予想コメント
推奨馬券
着順結果
配当
```

## スタックPR

- base: `feature/49-race-comment-contract`（#49）
- スタックの最終PR

## 検証

- `npm run lint` / `npx tsc --noEmit` パス
- 3状態すべてをローカルで確認（いずれもページは HTTP 200）
  - データあり: OpenAI / Claude の2カードが表示される
  - 未生成: 「予想データなし」
  - 取得失敗: コメント領域のみエラー表示、レース詳細の他の要素は表示継続
- PC（1280px）・モバイル（375px）でレイアウト崩れがないことを確認

## マイグレーション影響

なし（#49 のマイグレーションを含む）