### PR TITLE
出馬表の予想印を復活する

### DIFF
--- a/src/app/components/EntryTable.tsx
+++ b/src/app/components/EntryTable.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/app/components/ui/table"
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card"
 import { Badge } from "@/app/components/ui/badge"
-import { Entry } from "@prisma/client"
+import { Entry, Predict } from "@prisma/client"
 import { groupBy } from "lodash"
 import { HorseIndicatorLabels, IndicatorLabel, INSUFFICIENT_LABEL } from "@/app/lib/indicatorLabels"
 
@@ -13,6 +13,7 @@ type EntryWithMasters = Entry & {
 
 type Props = {
   entries: EntryWithMasters[]
+  predicts: Predict[]
   indicators?: HorseIndicatorLabels[]
 }
 
@@ -58,7 +59,7 @@ function IndicatorBadges({ labels }: { labels?: HorseIndicatorLabels }) {
   )
 }
 
-export function EntryTable({ entries, indicators = [] }: Props) {
+export function EntryTable({ entries, predicts, indicators = [] }: Props) {
   // 枠番でグループ化し、各グループ内で馬番順にソート
   const groupedEntries = Object.entries(groupBy(entries, "bracket_number"))
     .map(([bracketNumber, entriesInBracket]) => ({
@@ -68,6 +69,12 @@ export function EntryTable({ entries, indicators = [] }: Props) {
     .sort((a, b) => a.bracketNumber - b.bracketNumber)
 
   const indicatorMap = new Map(indicators.map((indicator) => [indicator.horseNumber, indicator]))
+  const marks = ["◎", "○", "▲", "△", "×"]
+  const predictMarks = new Map(
+    [...predicts]
+      .sort((a, b) => b.score - a.score)
+      .map((predict, index) => [predict.horse_number, marks[index] ?? "×"])
+  )
   // 指標が1件も無いレースでは列そのものを表示しない
   const hasIndicators = indicators.length > 0
 
@@ -88,6 +95,7 @@ export function EntryTable({ entries, indicators = [] }: Props) {
               <TableHead>馬齢</TableHead>
               <TableHead>騎手</TableHead>
               <TableHead>負担重量</TableHead>
+              <TableHead>予想印</TableHead>
               {hasIndicators && <TableHead className="min-w-[240px]">AI指標</TableHead>}
             </TableRow>
           </TableHeader>
@@ -107,6 +115,7 @@ export function EntryTable({ entries, indicators = [] }: Props) {
                     <TableCell>{entry.age}</TableCell>
                     <TableCell className="whitespace-nowrap">{entry.JockeyMaster?.name ?? "不明"}</TableCell>
                     <TableCell>{entry.jockey_weight}</TableCell>
+                    <TableCell>{predictMarks.get(entry.horse_number) ?? "×"}</TableCell>
                     {hasIndicators && (
                       <TableCell className="min-w-[240px]">
                         <IndicatorBadges labels={indicatorMap.get(entry.horse_number)} />

--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent } from "@/app/components/ui/card"
 import { EntryTable } from "@/app/components/EntryTable"
 import { RaceResultTable } from "@/app/components/RaceResultTable"
 import { PayoutTable } from "@/app/components/PayoutTable"
-import { Race, Entry, Result, Payout, RecommendedBet } from "@prisma/client"
+import { Race, Entry, Predict, Result, Payout, RecommendedBet } from "@prisma/client"
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
 import {
@@ -54,15 +54,16 @@ type EntryWithMasters = Entry & {
   JockeyMaster: { name: string }
 }
 
-type RaceWithEntries = Race & {
+type RaceWithEntriesAndPredicts = Race & {
   entries: EntryWithMasters[]
+  predicts: Predict[]
   results: Result[]
   payouts: Payout[]
   recommended_bets: RecommendedBet[]
 }
 
 
-async function getRaceWithEntries(id: number): Promise<RaceWithEntries | null> {
+async function getRaceWithEntries(id: number): Promise<RaceWithEntriesAndPredicts | null> {
   return prisma.race.findFirst({
     where: { id },
     include: {
@@ -72,6 +73,7 @@ async function getRaceWithEntries(id: number): Promise<RaceWithEntries | null> {
           JockeyMaster: true,
         },
       },
+      predicts: true,
       results: true,
       payouts: true,
       recommended_bets: true,
@@ -137,7 +139,7 @@ export default async function RacePage({ params }: { params: Promise<{ id: strin
           </div>
         </CardContent>
       </Card>
-      <EntryTable entries={race.entries} indicators={indicators} />
+      <EntryTable entries={race.entries} predicts={race.predicts} indicators={indicators} />
       <Suspense fallback={<RacePredictionCommentsSkeleton />}>
         <RacePredictionComments netkeibaRaceId={race.netkeiba_race_id} />
       </Suspense>


### PR DESCRIPTION
## 概要
PR #54 で削除した出馬表の予想印（◎・○・▲・△・×）を復活します。
既存のAI指標とレース予想コメントは維持し、予想印を併記します。

## 変更内容
- レース詳細取得時に `predicts` を再び取得
- `Predict.score` の降順で ◎・○・▲・△・× を割り当て
- 出馬表へ「予想印」列を追加

## テスト
- `npm run lint` 成功（既存の `StatisticsView.tsx` に警告1件）
- `git diff --check origin/main...HEAD` 成功
- セキュリティレビューで指摘なし
- `npx tsc --noEmit` はローカルのPrisma Clientが最新schemaから未生成のため、既存の `HorseIndicator` / `RacePredictionComment` 型で失敗（今回の変更箇所以外）

## マイグレーション影響
なし