### PR TITLE
AI予想コメント欄を一時的に非表示にする

### DIFF
--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -5,14 +5,9 @@ import { PayoutTable } from "@/app/components/PayoutTable"
 import { Race, Entry, Result, Payout, RecommendedBet } from "@prisma/client"
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
-import {
-  RacePredictionComments,
-  RacePredictionCommentsSkeleton,
-} from "@/app/components/RacePredictionComments"
 import { formatInTimeZone } from "date-fns-tz"
 import { prisma } from "@/lib/prisma"
 import { getHorseIndicatorLabels } from "@/app/lib/horseIndicators"
-import { Suspense } from "react"
 
 function getCombinedAccentClass(courseType: string, track: string): string {
   const courseAccent = getCourseAccentClass(courseType)
@@ -138,9 +133,6 @@ export default async function RacePage({ params }: { params: Promise<{ id: strin
         </CardContent>
       </Card>
       <EntryTable entries={race.entries} indicators={indicators} />
-      <Suspense fallback={<RacePredictionCommentsSkeleton />}>
-        <RacePredictionComments netkeibaRaceId={race.netkeiba_race_id} />
-      </Suspense>
       <RecommendedBets bets={race.recommended_bets} entries={race.entries} />
       <div className="mt-6 flex flex-col lg:flex-row gap-6">
         {race.results && race.results.length > 0 && (


### PR DESCRIPTION
## 概要
レース詳細画面のAI予想コメント表示欄を一時的に非表示にします。データ取得ロジックやコンポーネント、DBスキーマは残し、再表示しやすい状態を維持します。

## 変更内容
- レース詳細画面からAI予想コメント欄の描画を削除
- 関連する未使用importを削除

## テスト
- `npm run lint`（成功。既存の `StatisticsView.tsx` に警告1件）
- `npx tsc --noEmit --incremental false`（成功）
- `git diff --check`（成功）
- セキュリティ差分レビュー（指摘なし）