### PR TITLE
HorseIndicatorの保存スキーマをpredictorに合わせる

### DIFF
--- a/prisma/migrations/20260822000000_align_horse_indicator_with_predictor/migration.sql
+++ b/prisma/migrations/20260822000000_align_horse_indicator_with_predictor/migration.sql
@@ -1,0 +1,84 @@
+-- Align HorseIndicator with the JSON payload written by horecast-predictor.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'HorseIndicator'
+          AND column_name = 'freshness'
+          AND data_type <> 'jsonb'
+    ) THEN
+        ALTER TABLE "HorseIndicator"
+        ALTER COLUMN "freshness" TYPE JSONB
+        USING NULL::JSONB;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'HorseIndicator'
+          AND column_name = 'positive_factors'
+          AND data_type <> 'jsonb'
+    ) THEN
+        ALTER TABLE "HorseIndicator"
+        ALTER COLUMN "positive_factors" DROP DEFAULT,
+        ALTER COLUMN "positive_factors" TYPE JSONB USING '[]'::JSONB;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'HorseIndicator'
+          AND column_name = 'risks'
+          AND data_type <> 'jsonb'
+    ) THEN
+        ALTER TABLE "HorseIndicator"
+        ALTER COLUMN "risks" DROP DEFAULT,
+        ALTER COLUMN "risks" TYPE JSONB USING '[]'::JSONB;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'HorseIndicator'
+          AND column_name = 'warnings'
+          AND data_type <> 'jsonb'
+    ) THEN
+        ALTER TABLE "HorseIndicator"
+        ALTER COLUMN "warnings" DROP DEFAULT,
+        ALTER COLUMN "warnings" TYPE JSONB USING '[]'::JSONB;
+    END IF;
+END $$;
+
+ALTER TABLE "HorseIndicator"
+ALTER COLUMN "positive_factors" SET DEFAULT '[]'::JSONB,
+ALTER COLUMN "risks" SET DEFAULT '[]'::JSONB,
+ALTER COLUMN "warnings" SET DEFAULT '[]'::JSONB;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'horse_indicator_race_horse_number_key'
+          AND conrelid = 'public."HorseIndicator"'::regclass
+          AND contype = 'u'
+    ) THEN
+        ALTER TABLE "HorseIndicator"
+        ADD CONSTRAINT "horse_indicator_race_horse_number_key"
+        UNIQUE USING INDEX "horse_indicator_race_horse_number_key";
+    END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,12 +114,12 @@ model HorseIndicator {
   base_ability     Float?
   condition_fit    Float?
   pace_fit         Float?
-  freshness        Float?
+  freshness        Json?     @db.JsonB
   history_count    Int       @default(0)
   rank             Int?
-  positive_factors String[]  @default([])
-  risks            String[]  @default([])
-  warnings         String[]  @default([])
+  positive_factors Json      @default("[]") @db.JsonB
+  risks            Json      @default("[]") @db.JsonB
+  warnings         Json      @default("[]") @db.JsonB
   expected_pace    String?   @db.VarChar
   logic_version    String?   @db.VarChar
   is_partial       Boolean   @default(false)

--- a/src/app/lib/indicatorLabels.ts
+++ b/src/app/lib/indicatorLabels.ts
@@ -15,12 +15,11 @@ const ABILITY_LABELS = ["最上位", "上位", "標準", "やや下位", "下位
 const CONDITION_LABELS = ["高い", "やや高い", "標準", "やや不安", "不安"] as const
 /** 展開適性：pace_fit / pace_score */
 const PACE_LABELS = ["展開有利", "やや有利", "中立", "やや不利", "展開不利"] as const
-/** 近走状態：freshness（算出不可は判断材料不足） */
+/** 近走状態：freshness.days_since_last_race（算出不可は判断材料不足） */
 const FRESHNESS_LABELS = ["好調", "安定", "平行線", "やや不安"] as const
 
 /** 上位から順に区切るしきい値。50（同値）は中央のラベルへ入る */
 const FIVE_LEVEL_THRESHOLDS = [80, 60, 40, 20]
-const FOUR_LEVEL_THRESHOLDS = [75, 55, 35]
 
 export type IndicatorLabel = {
   label: string
@@ -48,7 +47,7 @@ export type HorseIndicatorSource = {
   base_ability: number | null
   condition_fit: number | null
   pace_fit: number | null
-  freshness: number | null
+  freshness: unknown
   history_count?: number | null
 }
 
@@ -65,6 +64,22 @@ function toLabel(
   const index = thresholds.findIndex((threshold) => score >= threshold)
   const level = index === -1 ? labels.length - 1 : index
   return { label: labels[level], level }
+}
+
+function toFreshnessLabel(freshness: unknown): IndicatorLabel {
+  if (freshness === null || typeof freshness !== "object" || Array.isArray(freshness)) {
+    return insufficient()
+  }
+
+  const daysSinceLastRace = (freshness as Record<string, unknown>).days_since_last_race
+  if (typeof daysSinceLastRace !== "number" || Number.isNaN(daysSinceLastRace)) {
+    return insufficient()
+  }
+
+  if (daysSinceLastRace <= 14) return { label: FRESHNESS_LABELS[0], level: 0 }
+  if (daysSinceLastRace <= 42) return { label: FRESHNESS_LABELS[1], level: 1 }
+  if (daysSinceLastRace <= 84) return { label: FRESHNESS_LABELS[2], level: 2 }
+  return { label: FRESHNESS_LABELS[3], level: 3 }
 }
 
 export function toHorseIndicatorLabels(
@@ -85,7 +100,7 @@ export function toHorseIndicatorLabels(
     ? toLabel(indicator.pace_fit, PACE_LABELS, FIVE_LEVEL_THRESHOLDS)
     : insufficient()
   const freshness = hasHistory
-    ? toLabel(indicator.freshness, FRESHNESS_LABELS, FOUR_LEVEL_THRESHOLDS)
+    ? toFreshnessLabel(indicator.freshness)
     : insufficient()
 
   return {


### PR DESCRIPTION
## 概要
horecast-predictorが保存するHorseIndicatorのJSONペイロードと、horecast側のSupabase／Prismaスキーマの差異を解消します。

## 変更内容
- freshness、positive_factors、risks、warningsをJSONBへ変更
- netkeiba_race_idとhorse_numberの複合UNIQUE制約を追加
- freshnessのJSON値を既存の画面表示ラベルへ変換
- Supabaseへの直接適用後もPrisma migrate deployで安全に記録できる冪等マイグレーションを追加

## テスト
- npx eslint src/app/lib/indicatorLabels.ts: 成功
- npx tsc --noEmit: 成功
- Prisma schema validate: 成功
- freshness表示変換の動作確認: 成功
- Supabase上でJSONB型、デフォルト値、複合キーupsertを確認
- セキュリティレビュー: 指摘なし
- 全体ESLintは.next生成物を対象にする既存設定のため省略
- ast-grepはプロジェクト設定が存在しないため省略