### PR TITLE
RacePredictionCommentの保存スキーマをpredictorに合わせる

### DIFF
--- a/docs/race-prediction-comment-contract.md
+++ b/docs/race-prediction-comment-contract.md
@@ -1,0 +1,33 @@
+# RacePredictionCommentの保存・参照契約
+
+この文書は、horecast-predictorが生成したレース予想コメントをHorecastへ保存し、画面に表示する際の契約を定める。初回は全体を通読する。実装やマイグレーションを変更するときは、「保存形式」と「アクセス制御」を確認する。
+
+## warningsは辞書配列のJSONBとして保存する
+
+`warnings` は `jsonb NOT NULL DEFAULT '[]'::jsonb` とする。各要素は警告内容を表す辞書で、`message` は文字列、`code` と `horse_number` は任意の文字列として扱う。
+
+```json
+[
+  {
+    "code": "missing_recent_races",
+    "message": "近走データが不足しています",
+    "horse_number": "7"
+  }
+]
+```
+
+Horecastの画面には `message` を表示する。`message` が文字列ではない要素は表示しない。`openai_batch_id` は内部処理用の値であり、画面表示用の型や公開レスポンスには含めない。
+
+## generated_atは必須のコメント生成時刻とする
+
+`generated_at` は `timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP` とする。predictorはコメントを保存するときに生成時刻を必ず指定する。DBのデフォルト値は、サーバー側から直接登録するときに値が省略されてもNULLを保存しないための補助として使う。
+
+## upsertはレース・プロバイダー・プロンプト版の組み合わせで行う
+
+一意キーは `netkeiba_race_id, provider, prompt_version` の3列とする。同じ組み合わせを再生成した場合は、新しい行を増やさず既存行を更新する。`netkeiba_race_id` には `Race.netkeiba_race_id` への外部キー制約を維持する。
+
+## ブラウザ用ロールには直接アクセスを許可しない
+
+`RacePredictionComment` はRLSを有効にし、anon・authenticated向けのポリシーは作成しない。HorecastはServer ComponentからPrisma経由で読み取り、ブラウザからSupabaseへ直接問い合わせない。predictorはサーバー側で管理するservice_roleキーを使って書き込む。
+
+service_roleキーはブラウザへ渡さない。本番適用前に、predictorのSSMパラメータ `SUPABASE_KEY` がservice_roleキーまたは同等の秘密キーであることを確認する。

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "postcss": "^8",
         "prisma": "^6.1.0",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.23.12",
         "typescript": "^5"
       }
     },
@@ -57,6 +58,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2487,6 +2930,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -5700,6 +6185,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "prisma generate  && prisma migrate deploy && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsx --test src/app/lib/racePredictionCommentWarnings.test.ts"
   },
   "dependencies": {
     "@next/third-parties": "^16.3.1",
@@ -35,6 +36,7 @@
     "postcss": "^8",
     "prisma": "^6.1.0",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.23.12",
     "typescript": "^5"
   }
 }

--- a/prisma/migrations/20260822010000_align_race_prediction_comment_contract/migration.sql
+++ b/prisma/migrations/20260822010000_align_race_prediction_comment_contract/migration.sql
@@ -1,0 +1,22 @@
+-- RacePredictionComment is empty in production at the time of this migration,
+-- but keep the conversion safe for existing text-array values and NULLs.
+ALTER TABLE public."RacePredictionComment"
+  ALTER COLUMN "warnings" DROP DEFAULT,
+  ALTER COLUMN "warnings" TYPE JSONB
+    USING COALESCE(to_jsonb("warnings"), '[]'::JSONB),
+  ALTER COLUMN "warnings" SET DEFAULT '[]'::JSONB,
+  ALTER COLUMN "warnings" SET NOT NULL;
+
+-- The predictor always supplies generated_at. The default also keeps direct
+-- server-side inserts valid when the timestamp is omitted.
+UPDATE public."RacePredictionComment"
+SET "generated_at" = COALESCE("generated_at", "created_at", CURRENT_TIMESTAMP)
+WHERE "generated_at" IS NULL;
+
+ALTER TABLE public."RacePredictionComment"
+  ALTER COLUMN "generated_at" SET DEFAULT CURRENT_TIMESTAMP,
+  ALTER COLUMN "generated_at" SET NOT NULL;
+
+-- No policies are added intentionally. Browser roles are denied by default;
+-- Prisma's server-side database role and Supabase service_role retain access.
+ALTER TABLE public."RacePredictionComment" ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,12 +89,12 @@ model RacePredictionComment {
   model_id            String?   @db.VarChar
   comment             String
   caveat              String?
-  warnings            String[]  @default([])
+  warnings            Json      @default("[]") @db.JsonB
   logic_version       String?   @db.VarChar
   prompt_version      String    @default("") @db.VarChar
   is_partial          Boolean   @default(false)
   source_generated_at DateTime? @db.Timestamptz(6)
-  generated_at        DateTime? @db.Timestamptz(6)
+  generated_at        DateTime  @default(now()) @db.Timestamptz(6)
   openai_batch_id     String?   @db.VarChar
   created_at          DateTime  @default(now()) @db.Timestamptz(6)
   updated_at          DateTime  @default(now()) @db.Timestamptz(6)

--- a/src/app/components/RacePredictionComments.tsx
+++ b/src/app/components/RacePredictionComments.tsx
@@ -26,10 +26,7 @@ function providerName(provider: string): string {
   return PROVIDER_NAMES[provider.toLowerCase()] ?? provider
 }
 
-function formatGeneratedAt(generatedAt: string | null): string | null {
-  if (!generatedAt) {
-    return null
-  }
+function formatGeneratedAt(generatedAt: string): string | null {
   const date = new Date(generatedAt)
   if (Number.isNaN(date.getTime())) {
     return null
@@ -88,8 +85,12 @@ function ProviderComment({ comment }: { comment: RacePredictionCommentView }) {
       )}
       {comment.warnings.length > 0 && (
         <ul className="mt-2 space-y-1 text-sm text-gray-600">
-          {comment.warnings.map((warning) => (
-            <li key={warning}>{warning}</li>
+          {comment.warnings.map((warning, index) => (
+            <li
+              key={`${warning.code ?? "warning"}-${warning.horseNumber ?? "race"}-${index}`}
+            >
+              {warning.message}
+            </li>
           ))}
         </ul>
       )}

--- a/src/app/lib/racePredictionCommentWarnings.test.ts
+++ b/src/app/lib/racePredictionCommentWarnings.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { parseRacePredictionWarnings } from "./racePredictionCommentWarnings"
+
+test("構造化されたwarningsを画面表示用の型へ変換できる", () => {
+  assert.deepEqual(
+    parseRacePredictionWarnings([
+      {
+        code: "missing_recent_races",
+        message: "近走データが不足しています",
+        horse_number: "7",
+      },
+    ]),
+    [
+      {
+        code: "missing_recent_races",
+        message: "近走データが不足しています",
+        horseNumber: "7",
+      },
+    ]
+  )
+})
+
+test("空配列は空のwarningsとして扱う", () => {
+  assert.deepEqual(parseRacePredictionWarnings([]), [])
+})
+
+test("不正なJSON要素は画面へ表示しない", () => {
+  assert.deepEqual(
+    parseRacePredictionWarnings([null, "legacy", { code: "no_message" }]),
+    []
+  )
+})

--- a/src/app/lib/racePredictionCommentWarnings.ts
+++ b/src/app/lib/racePredictionCommentWarnings.ts
@@ -1,0 +1,43 @@
+export type RacePredictionWarning = {
+  code: string | null
+  message: string
+  horseNumber: string | null
+}
+
+function stringValue(
+  value: Record<string, unknown>,
+  key: string
+): string | null {
+  const property = value[key]
+  return typeof property === "string" ? property : null
+}
+
+/**
+ * DBから受け取ったJSONを画面表示用の警告へ変換する。
+ * messageを持たない要素は、壊れたデータを画面へ出さないため除外する。
+ */
+export function parseRacePredictionWarnings(
+  value: unknown
+): RacePredictionWarning[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap((warning) => {
+    if (warning === null || typeof warning !== "object" || Array.isArray(warning)) {
+      return []
+    }
+
+    const object = warning as Record<string, unknown>
+    const message = stringValue(object, "message")
+    if (message === null) {
+      return []
+    }
+
+    return [{
+      code: stringValue(object, "code"),
+      message,
+      horseNumber: stringValue(object, "horse_number"),
+    }]
+  })
+}

--- a/src/app/lib/racePredictionComments.ts
+++ b/src/app/lib/racePredictionComments.ts
@@ -1,14 +1,18 @@
 import { RacePredictionComment } from "@prisma/client"
 import { prisma } from "@/lib/prisma"
+import {
+  parseRacePredictionWarnings,
+  RacePredictionWarning,
+} from "@/app/lib/racePredictionCommentWarnings"
 
 export type RacePredictionCommentView = {
   provider: string
   modelId: string | null
   comment: string
   caveat: string | null
-  warnings: string[]
+  warnings: RacePredictionWarning[]
   isPartial: boolean
-  generatedAt: string | null
+  generatedAt: string
 }
 
 /**
@@ -20,7 +24,7 @@ export type RacePredictionCommentsResult =
   | { status: "error"; comments: [] }
 
 function generatedTime(comment: RacePredictionComment): number {
-  return (comment.generated_at ?? comment.created_at).getTime()
+  return comment.generated_at.getTime()
 }
 
 /**
@@ -47,9 +51,9 @@ function toView(comment: RacePredictionComment): RacePredictionCommentView {
     modelId: comment.model_id,
     comment: comment.comment,
     caveat: comment.caveat,
-    warnings: comment.warnings,
+    warnings: parseRacePredictionWarnings(comment.warnings),
     isPartial: comment.is_partial,
-    generatedAt: (comment.generated_at ?? comment.created_at).toISOString(),
+    generatedAt: comment.generated_at.toISOString(),
   }
 }
 


### PR DESCRIPTION
## 概要
horecast-predictor PR #159が保存するレース予想コメントの契約に合わせ、RacePredictionCommentのwarningsとgenerated_at、RLS設定を更新します。

このPRは #63 を親とするStacked PRです。先に #63 をマージしてください。

## 変更内容
- warningsをtext配列からJSONBへ変換する再現可能なPrismaマイグレーションを追加
- warningsをJSONB・NOT NULL・空配列デフォルトへ統一
- generated_atを既存値補完後にNOT NULL化し、現在時刻をデフォルト設定
- RacePredictionCommentのRLSを有効化し、ブラウザ用ロールのポリシーは追加しない最小権限構成に変更
- 構造化warningsを検証してmessageを画面表示する型・変換処理を追加
- 保存形式、upsertキー、アクセス制御の契約ドキュメントを追加

## マイグレーション影響
- 既存のwarnings値とNULLをJSONBへ安全に変換します
- 既存の複合ユニーク制約とRaceへの外部キーは維持します
- 本番適用前にpredictorのSUPABASE_KEYがservice_roleまたは同等の秘密キーであることを確認してください

## テスト
- npm test: 3件成功
- TypeScript型検査: 成功
- 変更対象へのESLint: 成功
- Prisma schema validate / generate: 成功
- セキュリティレビュー: 指摘なし