### PR TITLE
AI予想コメント欄の表示を復活する

### DIFF
--- a/src/app/races/[id]/page.tsx
+++ b/src/app/races/[id]/page.tsx
@@ -5,9 +5,14 @@ import { PayoutTable } from "@/app/components/PayoutTable"
 import { Race, Entry, Predict, Result, Payout, RecommendedBet } from "@prisma/client"
 import { NavigationButtons } from "@/app/components/NavigationButtons"
 import { RecommendedBets } from "@/app/components/RecommendedBets"
+import {
+  RacePredictionComments,
+  RacePredictionCommentsSkeleton,
+} from "@/app/components/RacePredictionComments"
 import { formatInTimeZone } from "date-fns-tz"
 import { prisma } from "@/lib/prisma"
 import { getHorseIndicatorLabels } from "@/app/lib/horseIndicators"
+import { Suspense } from "react"
 
 function getCombinedAccentClass(courseType: string, track: string): string {
   const courseAccent = getCourseAccentClass(courseType)
@@ -135,6 +140,9 @@ export default async function RacePage({ params }: { params: Promise<{ id: strin
         </CardContent>
       </Card>
       <EntryTable entries={race.entries} predicts={race.predicts} indicators={indicators} />
+      <Suspense fallback={<RacePredictionCommentsSkeleton />}>
+        <RacePredictionComments netkeibaRaceId={race.netkeiba_race_id} />
+      </Suspense>
       <RecommendedBets bets={race.recommended_bets} entries={race.entries} />
       <div className="mt-6 flex flex-col lg:flex-row gap-6">
         {race.results && race.results.length > 0 && (


### PR DESCRIPTION
## 概要

#62 でレース詳細画面から一時的に外していた「AI予想コメント」欄を、再び表示するように戻します。

非表示の理由だった `RacePredictionComment` のスキーマ不整合は #63 / #64 で解消済みです。表示側のコンポーネントとデータ取得層はその際に修正が入っており、`generated_at` の非null化と `warnings` の型付きパースに対応済みのため、今回は呼び出し側の復元だけで足ります。

## 変更内容

- `src/app/races/[id]/page.tsx` に `RacePredictionComments` の呼び出しと import を復元
- 出馬表の直下、推奨馬券の上という #62 以前と同じ位置に配置
- 取得中は `Suspense` の `RacePredictionCommentsSkeleton` を表示し、コメントの取得がレース詳細画面全体の表示をブロックしないようにする

コメント欄の内部挙動は既存のままです。取得失敗時は「AI予想コメントを取得できませんでした」、未生成時は「予想データなし」を欄内に表示し、いずれもレース詳細画面の他の要素には影響しません。

## テスト

- `npm test` — 3件すべてパス（`racePredictionCommentWarnings` の変換ロジック）
- `npx tsc --noEmit` — 型エラーなし
- `npx eslint src/app/races/[id]/page.tsx src/app/components/RacePredictionComments.tsx` — 指摘なし

補足: `npm run lint` は現在リポジトリ全体で失敗します。Next.js 16 で `next lint` が廃止されたためで、`main` でも同様に落ちる既存の問題です。本PRとは無関係なので、代わりに ESLint CLI を直接実行しました。別途 `lint` スクリプトの移行が必要です。